### PR TITLE
Simple registering of custom rest endpoints.

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -25,6 +25,55 @@ module Restforce
       Restforce::Client.new(options)
     end
 
+    # Public: Create a custom Restforce::Client method linked to a custom apex
+    # REST service.
+    #
+    # service - The name of the REST endpoint. For example, if you access your
+    #           REST endpoint at /services/apexrest/FieldCase, the service would
+    #           be "FieldCase" (default: nil).
+    # options - A hash of options (default: {}).
+    #           :as - What the method should be named (default: the name of the service).
+    # block   - The block to execute when the custom method is called. The
+    #           block should always have the first parameter as "path", which
+    #           points to the location of the endpoint (e.g. '/services/apexrest/FieldCase').
+    #
+    # Examples
+    #
+    #   # Assuming you have an apex class on Salesforce like so:
+    #   @RestResource(urlMapping='/ValidateName')
+    #   global class RESTCaseController {
+    #     @HttpGet
+    #     global static Map<String, Boolean> validateName() {
+    #       String name = RestContext.request.params.get('name');
+    #       List<Account> accounts = [select Id, Name from Account where Name = :name];
+    #       return new Map<String, Boolean> { 'valid' => accounts.size() <= 0 };
+    #     }
+    #   }
+    #
+    #   # Register a method to utilize this rest endpoint.
+    #   Restforce.register('ValidateName', as: :validate_name) do |path, name|
+    #     response = get path, name: name
+    #     response.body['valid']
+    #   end
+    #
+    #   # Now we can call this method:
+    #   client.validate_name('foobar')
+    #   # => true
+    #   client.validate_name('sForce')
+    #   # => false
+    def register(service, options = {}, &block)
+      options = {
+        as: service.to_sym
+      }.merge(options)
+
+      Restforce::Client.class_eval do
+        define_method options[:as] do |*args|
+          args.unshift("/services/apexrest/#{service}")
+          instance_exec(*args, &block)
+        end
+      end
+    end
+
     # Public: Decodes a signed request received from Force.com Canvas.
     #
     # message       - The POST message containing the signed request from Salesforce.


### PR DESCRIPTION
http://wiki.developerforce.com/page/Creating_REST_APIs_using_Apex_REST

```
https://na8.salesforce.com/services/apexrest/FieldCase
```

``` ruby
Restforce.register('FieldCase')
client.field_case

Restforce.register('FieldCase', as: :foo_bar)
client.foo_bar

Restforce.register('FieldCase', as: :foo_bar) do |name|
   response = post '/services/apexrest/FieldCase', name: name
   response.body
end
client.foo_bar
```
