### PR TITLE
Allow http request read/open timeout to be set.

### DIFF
--- a/lib/restforce/client.rb
+++ b/lib/restforce/client.rb
@@ -15,7 +15,8 @@ module Restforce
     include Restforce::Client::API
 
     OPTIONS = [:username, :password, :security_token, :client_id, :client_secret, :host, :compress,
-       :api_version, :oauth_token, :refresh_token, :instance_url, :cache, :authentication_retries]
+       :api_version, :oauth_token, :refresh_token, :instance_url, :cache, :authentication_retries,
+       :timeout]
 
     # Public: Creates a new client instance
     #
@@ -47,6 +48,7 @@ module Restforce
     #                                  before raising an exception (default: 3).
     #
     #        :compress               - Set to true to have Salesforce compress the response (default: false).
+    #        :timeout                - Faraday connection request read/open timeout. (default: nil).
     #
     # Examples
     #

--- a/lib/restforce/client/connection.rb
+++ b/lib/restforce/client/connection.rb
@@ -19,7 +19,7 @@ module Restforce
 
       # Internal: Internal faraday connection where all requests go through
       def connection
-        @connection ||= Faraday.new(@options[:instance_url]) do |builder|
+        @connection ||= Faraday.new(@options[:instance_url], connection_options) do |builder|
           # Parses JSON into Hashie::Mash structures.
           builder.use      Restforce::Middleware::Mashify, self, @options
           # Handles multipart file uploads for blobs.
@@ -47,6 +47,13 @@ module Restforce
 
           builder.adapter  Faraday.default_adapter
         end
+      end
+
+      # Internal: Faraday Connection options
+      def connection_options
+        { :request => {
+            :timeout => @options[:timeout],
+            :open_timeout => @options[:timeout] } }
       end
 
       # Internal: Returns true if the middlware stack includes the

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -66,6 +66,9 @@ module Restforce
     # Set to true if you want responses from Salesforce to be gzip compressed.
     attr_accessor :compress
 
+    # Faraday request read/open timeout.
+    attr_accessor :timeout
+
     def api_version
       @api_version ||= '26.0'
     end

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -23,7 +23,7 @@ describe Restforce do
       its(:host)                   { should eq 'login.salesforce.com' }
       its(:authentication_retries) { should eq 3 }
       [:username, :password, :security_token, :client_id, :client_secret,
-       :oauth_token, :refresh_token, :instance_url, :compress].each do |attr|
+       :oauth_token, :refresh_token, :instance_url, :compress, :timeout].each do |attr|
         its(attr) { should be_nil }
       end
     end
@@ -54,7 +54,7 @@ describe Restforce do
   end
 
   describe '#configure' do
-    [:username, :password, :security_token, :client_id, :client_secret, :compress,
+    [:username, :password, :security_token, :client_id, :client_secret, :compress, :timeout,
      :oauth_token, :refresh_token, :instance_url, :api_version, :host, :authentication_retries].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|


### PR DESCRIPTION
Should fix errors like this:

```
A Faraday::Error::ConnectionFailed occurred in controller#index:

  end of file reached
  /usr/local/lib/ruby/1.9.1/openssl/buffering.rb:145:in `sysread_nonblock'
```

by doing this:

``` ruby
Restforce.configure do |config|
  config.timeout = 100
end
```
