### PR TITLE
Configurable http adapter.

### DIFF
--- a/lib/restforce/client/connection.rb
+++ b/lib/restforce/client/connection.rb
@@ -45,8 +45,12 @@ module Restforce
           # Compress/Decompress the request/response
           builder.use      Restforce::Middleware::Gzip, self, @options
 
-          builder.adapter  Faraday.default_adapter
+          builder.adapter  adapter
         end
+      end
+
+      def adapter
+        Restforce.configuration.adapter
       end
 
       # Internal: Faraday Connection options

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -69,6 +69,9 @@ module Restforce
     # Faraday request read/open timeout.
     attr_accessor :timeout
 
+    # Faraday adapter to use. Defaults to Faraday.default_adapter.
+    attr_accessor :adapter
+
     def api_version
       @api_version ||= '26.0'
     end
@@ -99,6 +102,10 @@ module Restforce
 
     def authentication_retries
       @authentication_retries ||= 3
+    end
+
+    def adapter
+      @adapter ||= Faraday.default_adapter
     end
 
     def logger

--- a/spec/lib/config_spec.rb
+++ b/spec/lib/config_spec.rb
@@ -22,6 +22,7 @@ describe Restforce do
       its(:api_version)            { should eq '26.0' }
       its(:host)                   { should eq 'login.salesforce.com' }
       its(:authentication_retries) { should eq 3 }
+      its(:adapter)                { should eq Faraday.default_adapter }
       [:username, :password, :security_token, :client_id, :client_secret,
        :oauth_token, :refresh_token, :instance_url, :compress, :timeout].each do |attr|
         its(attr) { should be_nil }


### PR DESCRIPTION
Allow the Faraday adapter to be configured.

``` ruby
Restforce.configure do |config|
  config.adapter = :excon
end
```
