### PR TITLE
Attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## HEAD
+
+*   Added ability to download attachments easily.
+
+    Example
+
+        attachment = client.query('select Id, Name, Body from Attachment').first
+        File.open(attachment.Name, 'wb') { |f| f.write(attachment.Body) }
+
 ## 1.0.6 (Feb 16, 2013)
 
 *   Added `url` method.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,17 @@ _See also: http://www.salesforce.com/us/developer/docs/api_rest/Content/dome_sob
 
 * * *
 
+### Downloading Attachments
+
+Restforce also makes it incredibly easy to download Attachments:
+
+```ruby
+attachment = client.query('select Id, Name, Body from Attachment').first
+File.open(attachment.Name, 'wb') { |f| f.write(attachment.Body) }
+```
+
+* * *
+
 ### Custom Apex REST endpoints
 
 You can use Restforce to interact with your custom REST endpoints, by using

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -9,6 +9,7 @@ module Restforce
   autoload :SignedRequest, 'restforce/signed_request'
   autoload :Collection,    'restforce/collection'
   autoload :Middleware,    'restforce/middleware'
+  autoload :Attachment,    'restforce/attachment'
   autoload :UploadIO,      'restforce/upload_io'
   autoload :SObject,       'restforce/sobject'
   autoload :Client,        'restforce/client'

--- a/lib/restforce/attachment.rb
+++ b/lib/restforce/attachment.rb
@@ -1,0 +1,23 @@
+module Restforce
+  class Attachment < Restforce::SObject
+
+    # Public: Returns the body of the attachment.
+    #
+    # Examples
+    #
+    #   attachment = client.query('select Id, Name, Body from Attachment').first
+    #   File.open(attachment.Name, 'wb') { |f| f.write(attachment.Body) }
+    def Body
+      ensure_id && ensure_body
+      @client.get(super).body
+    end
+
+  private
+
+    def ensure_body
+      return true if self.Body?
+      raise 'You need to query the Body for the record first.'
+    end
+
+  end
+end

--- a/lib/restforce/client/connection.rb
+++ b/lib/restforce/client/connection.rb
@@ -33,7 +33,7 @@ module Restforce
           # Ensures the instance url is set.
           builder.use      Restforce::Middleware::InstanceURL, self, @options
           # Parses returned JSON response into a hash.
-          builder.response :json
+          builder.response :json, :content_type => /\bjson$/
           # Caches GET requests.
           builder.use      Restforce::Middleware::Caching, cache, @options if cache
           # Follows 30x redirects.

--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -26,9 +26,13 @@ module Restforce
           # of sobject records.
           Restforce::Collection
         elsif val.has_key? 'attributes'
-          # When the hash contains an attributes key, it should be considered an
-          # sobject record
-          Restforce::SObject
+          if val['attributes']['type'] == 'Attachment'
+            Restforce::Attachment
+          else
+            # When the hash contains an attributes key, it should be considered an
+            # sobject record
+            Restforce::SObject
+          end
         else
           # Fallback to a standard Restforce::Mash for everything else
           Restforce::Mash

--- a/lib/restforce/sobject.rb
+++ b/lib/restforce/sobject.rb
@@ -56,7 +56,8 @@ module Restforce
   private
 
     def ensure_id
-      raise 'You need to query the Id for the record first.' unless self.Id?
+      return true if self.Id?
+      raise 'You need to query the Id for the record first.'
     end
 
   end

--- a/spec/lib/attachment_spec.rb
+++ b/spec/lib/attachment_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Restforce::Attachment do
+  include_context 'basic client'
+
+  let(:body_url) { '/services/data/v26.0/sobjects/Attachment/00PG0000006Hll5MAC/Body' }
+  let(:hash) { { 'Id' => '1234', 'Body' => body_url } }
+  let(:sobject) do
+    described_class.new(hash, client)
+  end
+
+  describe '.Body' do
+    it 'requests the body' do
+      client.should_receive(:get).with(body_url).and_return(double('response').as_null_object)
+      sobject.Body
+    end
+  end
+end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -439,8 +439,8 @@ shared_examples_for 'methods' do
     before do
       @query = stub_api_request('query\?q=SELECT%20some,%20fields%20FROM%20object').
         with(:headers => { 'Authorization' => "OAuth #{oauth_token}" }).
-        to_return(:status => 401, :body => fixture('expired_session_response')).then.
-        to_return(:status => 200, :body => fixture('sobject/query_success_response'))
+        to_return(:status => 401, :body => fixture('expired_session_response'), :headers => { 'Content-Type' => 'application/json' }).then.
+        to_return(:status => 200, :body => fixture('sobject/query_success_response'), :headers => { 'Content-Type' => 'application/json' })
 
       @login = stub_login_request(:with_body => "grant_type=password&client_id=client_id&client_secret=" \
         "client_secret&username=foo&password=barsecurity_token").

--- a/spec/lib/mash_spec.rb
+++ b/spec/lib/mash_spec.rb
@@ -19,8 +19,13 @@ describe Restforce::Mash do
     end
 
     context 'when the hash has an "attributes" key' do
-      let(:input) { { 'attributes' => nil } }
+      let(:input) { { 'attributes' => { 'type' => 'Account' } } }
       it { should eq Restforce::SObject }
+
+      context 'when the sobject type is an Attachment' do
+        let(:input) { { 'attributes' => { 'type' => 'Attachment' } } }
+        it { should eq Restforce::Attachment }
+      end
     end
 
     context 'else' do

--- a/spec/support/fixture_helpers.rb
+++ b/spec/support/fixture_helpers.rb
@@ -10,7 +10,7 @@ module FixtureHelpers
 
       stub = stub_request(options[:method], %r{/services/data/v#{options[:api_version]}/#{endpoint}})
       stub = stub.with(:body => options[:with_body]) if options[:with_body] && !RUBY_VERSION.match(/^1.8/)
-      stub = stub.to_return(:status => options[:status], :body => fixture(options[:fixture])) if options[:fixture]
+      stub = stub.to_return(:status => options[:status], :body => fixture(options[:fixture]), :headers => { 'Content-Type' => 'application/json'}) if options[:fixture]
       stub
     end
 


### PR DESCRIPTION
Better handling of Attachments, requested in #56. Lets you do the following:

``` ruby
attachment = client.query('select Id, Name, Body from Attachment').first
File.open(attachment.Name, 'wb') { |f| f.write(attachment.Body) }
```
