### PR TITLE
edit readme and add tooling api specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,22 @@ end
 
 You can use Restforce to decode signed requests from Salesforce. See [the example app](https://gist.github.com/4052312).
 
+
+## Tooling API
+
+To use the [Tooling API](http://www.salesforce.com/us/developer/docs/api_toolingpre/api_tooling.pdf), just pass in an optional parameter when initializing a new client:
+
+```ruby
+client = Restforce.new(:api => :tooling)
+client.list_sobjects
+```
+
+You can also toggle the api after the fact like so:
+
+```ruby
+client.api= :tooling
+```
+
 ## Contributing
 
 1. Fork it

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -31,6 +31,24 @@ shared_examples_for 'methods' do
     its([:security_token]) { should eq security_token }
   end
 
+  describe '.api' do
+    context 'by default' do
+      subject { client.api }
+      it { should eq :data }
+    end
+
+    context 'when set to tooling' do
+      subject { client.api=:tooling }
+      it { should eq :tooling }
+    end
+
+    context 'when passed as param to options' do
+      let(:client_options) { base_options.merge(:api => :tooling) }
+      subject { client.api }
+      it { should eq :tooling }
+    end
+  end
+
   describe '.instance_url' do
     subject { client.instance_url }
     it { should eq 'https://na1.salesforce.com' }


### PR DESCRIPTION
I experimented with this over the weekend, and I like the api flag and I think that it adds enough that it's definitely worth including.  I added a couple basic specs to the tooling branch, and updated the readme.  LMK what you think (and if i'm doing the pull request correctly.  should i have branched your tooling branch first?).

Its also worth noting that one difference between the data and tooling api is that there are no custom objects or fields.  So with a static set of endpoints, you could create methods that are less open ended and potentially combine more than one api call, eg:  `compile_apex_classes(apex_classes=[])`.  Thats where the question of 'Does this belong in restforce or elsewhere?' comes from.  But at minimum the above is definitely worth including.
