### PR TITLE
Add 'path' param to Restforce::Tooling::Client.api_path

### DIFF
--- a/lib/restforce/tooling/client.rb
+++ b/lib/restforce/tooling/client.rb
@@ -4,7 +4,7 @@ module Restforce
 
       private
 
-        def api_path
+        def api_path(path)
           super("tooling/#{path}")
         end
 


### PR DESCRIPTION
The new Restforce::Tooling::Client looks good, but I had to amend the api_path method to also accept a 'path' param to get it to work.
