### PR TITLE
Added proxy support

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -34,7 +34,7 @@ module Restforce
 
     # Internal: Faraday connection to use when sending an authentication request.
     def connection
-      @connection ||= Faraday.new(:url => "https://#{@options[:host]}") do |builder|
+      @connection ||= Faraday.new(faraday_options) do |builder|
         builder.use Restforce::Middleware::Mashify, nil, @options
         builder.response :json
         builder.use Restforce::Middleware::Logger, Restforce.configuration.logger, @options if Restforce.log?
@@ -58,6 +58,12 @@ module Restforce
           "#{k}=#{v}"
         end.join('&')
       end
+    end
+
+  private
+    def faraday_options
+      { :url   => "https://#{@options[:host]}",
+        :proxy => @options[:proxy_uri] }.reject { |k, v| v.nil? }
     end
   end
 end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Restforce::Middleware::Authentication do
   let(:options) do
     { :host => 'login.salesforce.com',
+      :proxy_uri => 'https://not-a-real-site.com',
       :authentication_retries => retries }
   end
 
@@ -37,7 +38,8 @@ describe Restforce::Middleware::Authentication do
   describe '.connection' do
     subject(:connection) { middleware.connection }
 
-    its(:url_prefix)     { should eq URI.parse('https://login.salesforce.com') }
+    its(:url_prefix)     { should eq(URI.parse('https://login.salesforce.com')) }
+    its(:proxy)          { should eq({ :uri => URI.parse('https://not-a-real-site.com') }) }
 
     describe '.builder' do
       subject(:builder) { connection.builder }


### PR DESCRIPTION
@ejholmes 
The :proxy_uri option was not being passed to the Faraday initializer,
which was causing issues when attempting to use a proxy.
