### PR TITLE
Add UrlEncoded middleware to auth client

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -35,6 +35,7 @@ module Restforce
     # Internal: Faraday connection to use when sending an authentication request.
     def connection
       @connection ||= Faraday.new(faraday_options) do |builder|
+        builder.use Faraday::Request::UrlEncoded
         builder.use Restforce::Middleware::Mashify, nil, @options
         builder.response :json
         builder.use Restforce::Middleware::Logger, Restforce.configuration.logger, @options if Restforce.log?


### PR DESCRIPTION
This commit fixes #72. 

Faraday adapters like :em_synchrony don't set the Content-Type header to urlencoded by default. Installing this middleware makes sure it's there if needed.
