### PR TITLE
Add authentication_callback option

### DIFF
--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -37,6 +37,9 @@ module Restforce
       #        :timeout                - Faraday connection request read/open timeout. (default: nil).
       #
       #        :proxy_uri              - Proxy URI: 'http://proxy.example.com:port' or 'http://user@pass:proxy.example.com:port'
+      #
+      #        :authentication_callback
+      #                                - A Proc that is called with the response body after a successful authentication.
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)
         @options = Hash[Restforce.configuration.options.map { |option| [option, Restforce.configuration.send(option)] }]

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -125,6 +125,9 @@ module Restforce
 
     option :proxy_uri, :default => lambda { ENV['PROXY_URI'] }
 
+    # A Proc that is called with the response body after a successful authentication.
+    option :authentication_callback
+
     def logger
       @logger ||= ::Logger.new STDOUT
     end

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -24,6 +24,7 @@ module Restforce
       raise Restforce::AuthenticationError, error_message(response) if response.status != 200
       @options[:instance_url] = response.body['instance_url']
       @options[:oauth_token]  = response.body['access_token']
+      @options[:authentication_callback].call(response.body) if @options[:authentication_callback]
       response.body
     end
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,7 @@ describe Restforce do
       its(:adapter)                { should eq Faraday.default_adapter }
       [:username, :password, :security_token, :client_id, :client_secret,
        :oauth_token, :refresh_token, :instance_url, :compress, :timeout,
-       :proxy_uri].each do |attr|
+       :proxy_uri, :authentication_callback].each do |attr|
         its(attr) { should be_nil }
       end
     end
@@ -55,7 +55,7 @@ describe Restforce do
   describe '#configure' do
     [:username, :password, :security_token, :client_id, :client_secret, :compress, :timeout,
      :oauth_token, :refresh_token, :instance_url, :api_version, :host, :authentication_retries,
-     :proxy_uri].each do |attr|
+     :proxy_uri, :authentication_callback].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
           config.send("#{attr}=", 'foobar')


### PR DESCRIPTION
We have a requirement to immediately persist an updated access token because another process may need to make a request and we do not want to take the time to repeat the authentication. This change makes it easy to fulfill that requirement.

After a successful authentication, the callback Proc is called with the response body. This can be used to store the updated access_token and/or instance_url after authentication.
