### PR TITLE
Connection should use Faraday adapter specified in options to Restforce client

### DIFF
--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -51,7 +51,7 @@ module Restforce
       end
 
       def adapter
-        Restforce.configuration.adapter
+        options[:adapter]
       end
 
       # Internal: Faraday Connection options

--- a/spec/unit/concerns/connection_spec.rb
+++ b/spec/unit/concerns/connection_spec.rb
@@ -11,4 +11,12 @@ describe Restforce::Concerns::Connection do
 
     it { should eq builder }
   end
+
+  describe '#adapter' do
+    before do
+      client.stub :options => {:adapter => :typhoeus}
+    end
+
+    its(:adapter) { should eq(:typhoeus) }
+  end
 end


### PR DESCRIPTION
Currently, connection always uses Faraday.default_adapter even though I've supplied other adapter as an option to Restforce client: `Restforce.new(:adapter => :typhoeus)`. It looks like a bug, since `config.rb` has such option defined with a default value equaling to `Faraday.default_adapter`.

I've updated the `connection.rb` to take adapter from `options` and included a test.
