### PR TITLE
Add select action to retreive only select fields from an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,18 @@ client.find('Account', '1234', 'Some_External_Id_Field__c')
 # => #<Restforce::SObject Id="001D000000INjVe" Name="Test" LastModifiedBy="005G0000002f8FHIAY" ... >
 ```
 
+### select
+
+```ruby
+client.select('Account', '001D000000INjVe', ["Id"])
+# => {"attributes" : {"type" : "Account","url" : "/services/data/v20.0/sobjects/Account/001D000000INjVe"},
+#   "Id" : "001D000000INjVe"}
+
+client.select('Account', '001D000000INjVe', ["Id"], 'Some_External_Id_Field__c')
+# => {"attributes" : {"type" : "Account","url" : "/services/data/v20.0/sobjects/Account/Some_External_Id_Field__c/001D000000INjVe"},
+#   "Id" : "003F000000BGIn3"}
+```
+
 ### search
 
 ```ruby

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -300,6 +300,23 @@ module Restforce
         api_get(field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}").body
       end
 
+      # Public: Finds a single record and returns select fields.
+      #
+      # sobject - The String name of the sobject.
+      # id      - The id of the record. If field is specified, id should be the id
+      #           of the external field.
+      # select  - A String array denoting the fields to select.  If nil or empty array
+      #           is passed, all fields are selected.  
+      # field   - External ID field to use (default: nil).
+      #
+      def select(sobject, id, select, field=nil)
+        path = field ? "sobjects/#{sobject}/#{field}/#{id}" : "sobjects/#{sobject}/#{id}"
+        path << "?fields=#{select.join(",")}" if select && select.any?
+        
+        api_get(path).body
+      end
+
+
     private
 
       # Internal: Returns a path to an api endpoint

--- a/spec/fixtures/sobject/sobject_select_success_response.json
+++ b/spec/fixtures/sobject/sobject_select_success_response.json
@@ -1,0 +1,8 @@
+{
+  "attributes" : {
+    "type" : "Whizbang",
+    "url" : "/services/data/v20.0/sobjects/Whizbang/23foo"
+  },
+ "External_Field__c" : "1234",
+ "Id" : "23foo"
+}

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -202,6 +202,43 @@ shared_examples_for Restforce::AbstractClient do
     end
   end
 
+  describe '.select' do
+    context 'when no external id is specified' do
+      context 'when no select list is specified' do
+        requests 'sobjects/Account/1234',
+        :fixture => 'sobject/sobject_select_success_response'
+
+        subject { client.select('Account', '1234', nil, nil) }
+        it { should be_a Hash }
+      end
+      context 'when select list is specified' do
+        requests 'sobjects/Account/1234\?fields=External_Field__c',
+        :fixture => 'sobject/sobject_select_success_response'
+
+        subject { client.select('Account', '1234', ['External_Field__c']) }
+        it { should be_a Hash }
+      end
+    end
+
+    context 'when an external id is specified' do
+      context 'when no select list is specified' do
+        requests 'sobjects/Account/External_Field__c/1234',
+        :fixture => 'sobject/sobject_select_success_response'
+
+        subject { client.select('Account', '1234', nil, 'External_Field__c') }
+        it { should be_a Hash }
+      end
+
+      context 'when select list is specified' do
+        requests 'sobjects/Account/External_Field__c/1234\?fields=External_Field__c',
+        :fixture => 'sobject/sobject_select_success_response'
+
+        subject { client.select('Account', '1234', ['External_Field__c'], 'External_Field__c') }
+        it { should be_a Hash }
+      end
+    end
+  end
+
   describe '.authenticate!' do
     subject(:authenticate!) { client.authenticate! }
 

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -241,4 +241,53 @@ describe Restforce::Concerns::API do
       end
     end
   end
+
+  describe '.select' do
+    let(:sobject)    { 'Whizbang' }
+    let(:id)         { '1234' }
+    let(:field)      { nil }
+    let(:select)     { nil }
+    subject(:result) { client.select(sobject, id, select, field) }
+
+    context 'when no external id is specified' do
+      context 'when no select list is specified' do
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/1234').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+      context 'when select list is specified' do
+        let(:select) { [:External_ID__c] }
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/1234?fields=External_ID__c').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+    end
+
+    context 'when an external id is specified' do
+      let(:field) { :External_ID__c }
+      context 'when no select list is specified' do
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/External_ID__c/1234').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+      context 'when select list is specified' do
+        let(:select) { [:External_ID__c] }
+        it 'returns the full representation of the object' do
+          client.should_receive(:api_get).
+            with('sobjects/Whizbang/External_ID__c/1234?fields=External_ID__c').
+            and_return(response)
+          expect(result).to eq response.body
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
I hope this is something that others can find useful.  I need to retrieve only a couple of fields from a sobject in my project.  I want to do this as efficiently as possible since I'm building out a REST api that depends on this query.  

I like the elegant syntax that Restforce.find() give me, because I don't want to write soql queries.  Yet the problem with find is that it always retrieves the whole sobject.  In my case this is a very large table and takes much longer to return.  So query is the fastest method for me.  

Here is my solution.  use the REST-ful api endpoint like find does, but passing in field specifications.  I created a new method called "select" rather than modifying "find" to avoid breaking changes.  

Benchmarks: 
[1] pry(main)> client = Restforce.new
=> #Restforce::Data::Client...
[2] pry(main)> Benchmark.measure{ client.query("select My_Custom_field__c from my__c  where Account__c = \'123456789012345678\'") }
=>   0.080000   0.010000   0.090000 (  1.296294)

[1] pry(main)> client = Restforce.new
[4] pry(main)> Benchmark.measure{ client.select('my__c', "123456789012345678-env",  ["Id", "My_Custom_field__c"], 'Parent_Id__c')}
=>   0.050000   0.010000   0.060000 (  0.398572)
