### PR TITLE
Update gem dependency

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '~> 0.8.4'
   gem.add_dependency 'faraday_middleware', '>= 0.8.8'
   gem.add_dependency 'json', ['>= 1.7.5', '< 1.9.0']
-  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.1']
+  gem.add_dependency 'hashie', ['>= 1.2.0', '< 2.2']
 
   gem.add_development_dependency 'rspec', '~> 2.14.0'
   gem.add_development_dependency 'webmock', '~> 1.13.0'


### PR DESCRIPTION
Allow hashie 2.1.x. 

Change log
https://github.com/intridea/hashie/blob/master/CHANGELOG.md

Diff
https://github.com/intridea/hashie/compare/v2.0.5...v2.1.2

hashie v2.2 (It hasn't been released yet, though) and v3.0.0 have inconvertibility.
https://github.com/intridea/hashie/blob/master/UPGRADING.md
