### PR TITLE
add a page_size method to Restforce::Collection

### DIFF
--- a/lib/restforce/collection.rb
+++ b/lib/restforce/collection.rb
@@ -20,6 +20,10 @@ module Restforce
       end
     end
 
+    # Return the size of each page in the collection
+    def page_size
+      @raw_page['records'].size
+    end
 
     # Return the size of the Collection without making any additional requests.
     def size

--- a/spec/unit/collection_spec.rb
+++ b/spec/unit/collection_spec.rb
@@ -13,6 +13,7 @@ describe Restforce::Collection do
       its(:size)           { should eq 1 }
       its(:has_next_page?) { should be_false }
       it                   { should have_client client }
+      its(:page_size)      { should eq 1 }
 
       describe 'each record' do
         it { should be_all { |record| expect(record).to be_a Restforce::SObject } }
@@ -34,6 +35,7 @@ describe Restforce::Collection do
         its(:first) { should be_a Restforce::SObject }
         its(:current_page) { should be_a Array }
         its(:current_page) { should have(1).element }
+        its(:page_size)    { should eq 1 }
       end
 
       context 'when all of the values are being requested' do


### PR DESCRIPTION
I have a Salesforce query that returns many results using the lazy-fetched enumerable Restforce::Collection.  Something like 

``` ruby
results = restforce_client.query("Select Id from #{sf_class}")
results.each_slice(1_000) do |slice| 
  delay_send_spam_email(slice)
end
```

Using each_slice with the SF page size seems very clean, and efficient, since I can fetch a single page of results, and only get the next page when I'm ready to process it.
But sometimes SF returns pages of 1k results, sometimes 2k, and I don't want to have to figure that out.

So I'd like to do results.each_slice(results.page_size) do |slice| ...
