### PR TITLE
Add a link to ActiveForce on the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,13 @@ call `Restforce.tooling` instead of `Restforce.new`:
 client = Restforce.tooling(...)
 ```
 
+## Links
+
+If you need a full Active Record experience, may be you can use
+[ActiveForce](https://github.com/ionia-corporation/active_force) that wraps
+Restforce and adds Associations, Query Building (like AREL), Validations and
+Callbacks.
+
 ## Contributing
 
 1. Fork it


### PR DESCRIPTION
Hi, would you add a link to ActiveForce,

This gem is based on a [gist from @ejholmes](https://gist.github.com/ejholmes/5154415) that you posted some time ago, it wraps Restforce in an ActiveRecord like functionality, adding associations, query builder (AREL like), and ActiveModel.
