### PR TITLE
Implement push topic replay

### DIFF
--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -44,12 +44,12 @@ module Restforce
       end
 
       class ReplayExtension
-        def initialize options
+        def initialize(options)
           @channels = options[:channels]
           @replay = options[:replay]
         end
 
-        def outgoing message, callback
+        def outgoing(message, callback)
           # Leave non-subscribe messages alone
           unless message['channel'] == '/meta/subscribe'
             return callback.call(message)

--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -91,7 +91,6 @@ module Restforce
             handler
           end
         end
-
       end
     end
   end

--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -7,8 +7,10 @@ module Restforce
       # block    - A block to run when a new message is received.
       #
       # Returns a Faye::Subscription
-      def subscribe(channels, &block)
-        faye.subscribe Array(channels).map { |channel| "/topic/#{channel}" }, &block
+      def subscribe(channels, options = {}, &block)
+        @replay = options[:replay]
+        @channels = Array(channels)
+        faye.subscribe @channels.map { |channel| "/topic/#{channel}" }, &block
       end
 
       # Public: Faye client to use for subscribing to PushTopics
@@ -19,17 +21,49 @@ module Restforce
 
         url = "#{options[:instance_url]}/cometd/#{options[:api_version]}"
 
-        @faye ||= Faye::Client.new(url).tap do |client|
-          client.set_header 'Authorization', "OAuth #{options[:oauth_token]}"
+        unless @faye
+          @faye = Faye::Client.new(url).tap do |client|
+            client.set_header 'Authorization', "OAuth #{options[:oauth_token]}"
 
-          client.bind 'transport:down' do
-            Restforce.log "[COMETD DOWN]"
-            client.set_header 'Authorization', "OAuth #{authenticate!.access_token}"
+            client.bind 'transport:down' do
+              Restforce.log "[COMETD DOWN]"
+              client.set_header 'Authorization', "OAuth #{authenticate!.access_token}"
+            end
+
+            client.bind 'transport:up' do
+              Restforce.log "[COMETD UP]"
+            end
           end
 
-          client.bind 'transport:up' do
-            Restforce.log "[COMETD UP]"
+          if @replay
+            @faye.add_extension ReplayExtension.new(channels: @channels, replay: @replay)
           end
+        end
+
+        @faye
+      end
+
+      class ReplayExtension
+        def initialize options
+          @channels = options[:channels]
+          @replay = options[:replay]
+        end
+
+        def outgoing message, callback
+          # Leave non-subscribe messages alone
+          unless message['channel'] == '/meta/subscribe'
+            return callback.call(message)
+          end
+
+          # Set the replay value for the each channel
+          message['ext'] ||= {}
+          message['ext']['replay'] = {}
+          @channels.each do |channel|
+            message['ext']['replay']["/topic/#{channel}"] = @replay
+          end
+
+          # Carry on and send the message to the server
+          callback.call message
         end
       end
     end

--- a/spec/unit/concerns/streaming_spec.rb
+++ b/spec/unit/concerns/streaming_spec.rb
@@ -17,7 +17,6 @@ describe Restforce::Concerns::Streaming, event_machine: true do
     end
 
     context "replay_handlers" do
-
       before {
         faye_double.should_receive(:subscribe).at_least(1)
         client.stub faye: faye_double
@@ -42,7 +41,6 @@ describe Restforce::Concerns::Streaming, event_machine: true do
           'channel3' => 3
         )
       end
-
     end
   end
 
@@ -69,7 +67,8 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         faye_double.should_receive(:set_header).with('Authorization', 'OAuth secret2')
         faye_double.should_receive(:bind).with('transport:down').and_yield
         faye_double.should_receive(:bind).with('transport:up').and_yield
-        faye_double.should_receive(:add_extension).with(kind_of(Restforce::Concerns::Streaming::ReplayExtension))
+        faye_double.should_receive(:add_extension).with \
+          kind_of(Restforce::Concerns::Streaming::ReplayExtension)
         subject
       end
     end
@@ -79,7 +78,6 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         expect { subject }.to raise_error
       end
     end
-
   end
 
   describe Restforce::Concerns::Streaming::ReplayExtension do
@@ -129,7 +127,7 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         }
       }
 
-      extension.incoming(message, -> m { })
+      extension.incoming(message, -> m {})
       handler.should eq('channel1' => 42)
     end
 
@@ -142,7 +140,7 @@ describe Restforce::Concerns::Streaming, event_machine: true do
         'data' => {}
       }
 
-      extension.incoming(message, -> m { })
+      extension.incoming(message, -> m {})
       handler.should eq('channel1' => 41)
     end
 
@@ -163,6 +161,5 @@ describe Restforce::Concerns::Streaming, event_machine: true do
     def read_replay(message)
       message.fetch('ext', {})['replay']
     end
-
   end
 end

--- a/spec/unit/concerns/streaming_spec.rb
+++ b/spec/unit/concerns/streaming_spec.rb
@@ -146,11 +146,11 @@ describe Restforce::Concerns::Streaming, event_machine: true do
 
     private
 
-    def subscribe(extension, to:)
+    def subscribe(extension, options = {})
       output = nil
       message = {
         'channel' => '/meta/subscribe',
-        'subscription' => "/topic/#{to}"
+        'subscription' => "/topic/#{options[:to]}"
       }
       extension.outgoing(message, -> m {
         output = m


### PR DESCRIPTION
Thanks to the existing code in Restforce, I was able to get up and running with the PushTopic streaming API in just a few lines of code. We have used this library on a couple of projects now.

For PushTopics, Salesforce added [the ability to replay messages](https://developer.salesforce.com/docs/atlas.en-us.api_streaming.meta/api_streaming/using_streaming_api_durability.htm) (see #237). This PR adds an options hash to the `subscribe` method on clients, which allows us to pass a message id to replay from using a client extension. With this code, you can replay messages:

```
client.subscribe push_topic_name, replay: 7 do |message|
  # message handler here
end
```

This will replay message 8 and up (based on Salesforce's documentation of this feature.) I have verified the functionality with a local script that points to this PR's version of the gem.

---

I am pushing this up for initial feedback. I think it needs at least a little more work.

One thing is that the current design does not let you easily subscribe to some channels with a replay id, and subsequently subscribe to others with no replay id. This is because there is only one Faye client initialized in total (it is cached between `subscribe`s.)

I think we might be able to remove the extension by storing it and then removing it later if we subscribe with no replay id, but it seems a little clunky. I wanted to see what the intent of the `faye` method is or why we want to only create one Faye client in the existing code. It probably didn't matter before since we were never modifying the client, but now that we are, it is a little more complicated. I am guessing the method was made public just for testing purposes based on the associated test and a search of the code, but wasn't sure of the intent of it. It seems like if we made a new client for each call to `subscribe` that we could easily pass in replay id or not and not have any interference between calls.

Additionally, I'd like to add tests and documentation for this feature and clean up the the logging (it's a bit verbose.) I'd also be curious to know if there is a more preferred place to put the `ReplayExtension` class, since I just lumped it in to the existing streaming module file.

---

Note that if you try to replay a message that is already expired (was created 24 hours or more ago), you will get the following error when attempting to subscribe to the channel:

```
#<Faye::Error:0x007fe9361df548 @code=nil, @params=[], @message="400::The replayId {2} you provided was invalid.  Please provide a valid ID, -2 to replay all events, or -1 to replay only new events.">
```

The best solution would seem to be to either increase the number you are replaying until you find a good one, or to use "-2" to replay all possible messages that Salesforce still has.

---

Useful resources:
- [cometdReplayExtension.js](https://github.com/developerforce/StreamingReplayClientExtensions/blob/48ce54bb9ef939ff13c73302a0f33786c5c343f2/javascript/cometdReplayExtension.js) (this gave a lot of detail that was useful)
- [Faye client extensions documentation](https://faye.jcoglan.com/ruby/extensions.html) (pretty much used this exact template for the extension)
- [Faye Ruby client example](https://github.com/faye/faye/blob/master/examples/ruby/client.rb)
