### PR TITLE
When configuring an API version, check that it's valid

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -42,6 +42,7 @@ module Restforce
   AuthenticationError = Class.new(Error)
   UnauthorizedError   = Class.new(Error)
   APIVersionError     = Class.new(Error)
+  InvalidOptionError  = Class.new(Error)
 
   class << self
     # Alias for Restforce::Data::Client.new

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -58,7 +58,7 @@ describe Restforce do
 
   describe '#configure' do
     [:username, :password, :security_token, :client_id, :client_secret, :compress,
-     :timeout, :oauth_token, :refresh_token, :instance_url, :api_version, :host, :mashify,
+     :timeout, :oauth_token, :refresh_token, :instance_url, :host, :mashify,
      :authentication_retries, :proxy_uri, :authentication_callback, :ssl,
      :request_headers, :log_level, :logger].each do |attr|
       it "allows #{attr} to be set" do
@@ -67,6 +67,21 @@ describe Restforce do
         end
         expect(Restforce.configuration.send(attr)).to eq 'foobar'
       end
+    end
+
+    it "allows api_version to be set to a valid version" do
+      Restforce.configure do |config|
+        config.send("api_version=", '38.0')
+      end
+      expect(Restforce.configuration.send(:api_version)).to eq '38.0'
+    end
+
+    it "doesn't allow api_version to be set to an invalid version" do
+      expect do
+        Restforce.configure do |config|
+          config.send("api_version=", 38)
+        end
+      end.to raise_error(Restforce::InvalidOptionError, /not a valid API version/)
     end
   end
 


### PR DESCRIPTION
Salesforce API versions are string representations of a number to one decimal place, for example `"38.0"` or `"40.0"`.

As noted by @wmadden [in his comment](https://github.com/ejholmes/restforce/issues/160#issuecomment-256888846), if you set an invalid API version, the Salesforce API just returns an unhelpful 404, and we raise a `Faraday::ResourceNotFound`. It is not terribly clear when this happens the problem is your API version, which gets put in the URL.

This tweaks `Restforce::Configuration::Option` to allow an option to have a validator, which is used to check values provided when they are set. You specify a lambda which is called, and may
raise an error, much like we use for specifying defaults.

We then add a validator for the `api_version` option, comparing the provided value to a regular expression, and raising an `InvalidOptionError` with a helpful message if it's invalid.