### PR TITLE
Upgrade rubocop to v0.51.0

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'hashie', ['>= 1.2.0', '< 4.0']
 
-  gem.add_development_dependency 'rspec', '~> 2.14.0'
-  gem.add_development_dependency 'webmock', '~> 3.1.0'
-  gem.add_development_dependency 'simplecov', '~> 0.15.0'
-  gem.add_development_dependency 'rubocop', '~> 0.50.0'
-  gem.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
   gem.add_development_dependency 'faye' unless RUBY_PLATFORM == 'java'
+  gem.add_development_dependency 'rspec', '~> 2.14.0'
+  gem.add_development_dependency 'rspec_junit_formatter', '~> 0.3.0'
+  gem.add_development_dependency 'rubocop', '~> 0.51.0'
+  gem.add_development_dependency 'simplecov', '~> 0.15.0'
+  gem.add_development_dependency 'webmock', '~> 3.1.0'
 end


### PR DESCRIPTION
Sort dependencies alpabetically. See https://github.com/bbatsov/rubocop/pull/4874