### PR TITLE
Ensure write access by configuration

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -150,6 +150,9 @@ module Restforce
     # Set a log level for logging when Restforce.log is set to true, defaulting to :debug
     option :log_level, default: :debug
 
+    # Set to true if you to disable data changes in salesforce
+    option :read_only, default: false
+
     def options
       self.class.options
     end

--- a/lib/restforce/sobject.rb
+++ b/lib/restforce/sobject.rb
@@ -22,11 +22,13 @@ module Restforce
     #   account.Name = 'Foobar'
     #   account.save
     def save
+      ensure_write_access
       ensure_id
       @client.update(sobject_type, attrs)
     end
 
     def save!
+      ensure_write_access
       ensure_id
       @client.update!(sobject_type, attrs)
     end
@@ -38,11 +40,13 @@ module Restforce
     #   account = client.query('select Id, Name from Account').first
     #   account.destroy
     def destroy
+      ensure_write_access
       ensure_id
       @client.destroy(sobject_type, self.Id)
     end
 
     def destroy!
+      ensure_write_access
       ensure_id
       @client.destroy!(sobject_type, self.Id)
     end
@@ -62,6 +66,11 @@ module Restforce
     def ensure_id
       return true if self.Id?
       raise ArgumentError, 'You need to query the Id for the record first.'
+    end
+
+    def ensure_write_access
+      return true unless Restforce.configuration.read_only
+      raise Restforce::UnauthorizedError, 'You are in read only mode.'
     end
   end
 end


### PR DESCRIPTION
Hey, 

a little change request. Since it seems not possible to configure connected apps in Salesforce as read only, it would be awesome to configurate Restforce with a `read_only` flag.

Useful for envirouments where you want to read data without calling `save`, `save!`, `destroy` or `destroy!` on them.