### PR TITLE
removes leading slash from `api_get` calls

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -81,7 +81,7 @@ module Restforce
       def get_updated(sobject, start_time, end_time)
         start_time = start_time.utc.iso8601
         end_time = end_time.utc.iso8601
-        url = "/sobjects/#{sobject}/updated/?start=#{start_time}&end=#{end_time}"
+        url = "sobjects/#{sobject}/updated/?start=#{start_time}&end=#{end_time}"
         api_get(url).body
       end
 
@@ -101,7 +101,7 @@ module Restforce
       def get_deleted(sobject, start_time, end_time)
         start_time = start_time.utc.iso8601
         end_time = end_time.utc.iso8601
-        url = "/sobjects/#{sobject}/deleted/?start=#{start_time}&end=#{end_time}"
+        url = "sobjects/#{sobject}/deleted/?start=#{start_time}&end=#{end_time}"
         api_get(url).body
       end
 

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -27,7 +27,7 @@ describe Restforce::Concerns::API do
     it 'returns the body' do
       start_string = '2002-10-31T00:02:02Z'
       end_string = '2003-10-31T00:02:02Z'
-      url = "/sobjects/Whizbang/updated/?start=#{start_string}&end=#{end_string}"
+      url = "sobjects/Whizbang/updated/?start=#{start_string}&end=#{end_string}"
       client.should_receive(:api_get).
         with(url).
         and_return(response)
@@ -43,7 +43,7 @@ describe Restforce::Concerns::API do
     it 'returns the body' do
       start_string = '2002-10-31T00:02:02Z'
       end_string = '2003-10-31T00:02:02Z'
-      url = "/sobjects/Whizbang/deleted/?start=#{start_string}&end=#{end_string}"
+      url = "sobjects/Whizbang/deleted/?start=#{start_string}&end=#{end_string}"
       client.should_receive(:api_get).
         with(url).
         and_return(response)


### PR DESCRIPTION
There is already a slash in the `api_path` method below and the duplicate slashes is causing us to get 404 errors when using `get_updated`. 

https://github.com/restforce/restforce/blob/467be4f6db4db10c64b1ec7fa48cb47de46f548a/lib/restforce/concerns/api.rb#L480