### PR TITLE
drop Gzip middleware for httpclient adapter

### DIFF
--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -47,7 +47,9 @@ module Restforce
           # Parses returned JSON response into a hash.
           builder.response :json, content_type: /\bjson$/
           # Compress/Decompress the request/response
-          builder.use      Restforce::Middleware::Gzip, self, options
+          unless adapter == :httpclient
+            builder.use      Restforce::Middleware::Gzip, self, options
+          end
           # Inject custom headers into requests
           builder.use      Restforce::Middleware::CustomHeaders, self, options
           # Log request/responses


### PR DESCRIPTION
Faraday had enabled gzip decompression for httpclient by default since v0.9.2.
#https://github.com/lostisland/faraday/pull/457

Therefore, no need of `Gzip` middleware for decompression.
