### PR TITLE
Fix upsert! regression on empty String response body

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -380,7 +380,7 @@ module Restforce
             api_patch "sobjects/#{sobject}/#{field}/#{CGI.escape(external_id)}", attrs
           end
 
-        response&.body&.fetch('id', nil) ? response.body['id'] : true
+        response.body.respond_to?(:fetch) ? response.body.fetch('id', true) : true
       end
 
       # Public: Delete a record.

--- a/spec/unit/concerns/api_spec.rb
+++ b/spec/unit/concerns/api_spec.rb
@@ -350,6 +350,16 @@ describe Restforce::Concerns::API do
             and_return(response)
           expect(result).to be_true
         end
+
+        context 'and the response body is a string' do
+          it 'returns true' do
+            response.stub(:body) { '' }
+            client.should_receive(:api_patch).
+              with('sobjects/Whizbang/External_ID__c/1234', {}).
+              and_return(response)
+            expect(result).to be_true
+          end
+        end
       end
 
       context 'when the record is found and created' do


### PR DESCRIPTION
This fixes a regression introduced in b3a52e8cfcfd for the case when
response body is not a Hash but an empty String.

*Expected behavior*:
it returns `true`

*Current behavior*:
it raises `undefined method 'fetch' for "":String`


Example request/response:

```bash
D, [2018-08-03T11:27:05.718522 #4] DEBUG -- request:
  url: "https://obfuscated--test--url.my.salesforce.com/services/oauth2/token"
  method: :post
  headers: {"User-Agent"=>"Faraday v0.12.2", "Content-Type"=>"application/x-www-form-urlencoded"}
  body: "grant_type=password&client_id=..."
D, [2018-08-03T11:27:06.426882 #4] DEBUG -- response:
  status: "200"
  headers: {"date"=>"Fri, 03 Aug 2018 11:27:06 GMT", "strict-transport-security"=>"max-age=31536002; includeSubDomains", ..., "connection"=>"close"}
  body: "{\"access_token\":\"token\",\"instance_url\":\"https://obfuscated--test--url.my.salesforce.com\",\"id\":\"https://test.salesforce.com/id/00Dq00000001BKzEAM/00561000001SZGMAA4\",\"token_type\":\"Bearer\",\"issued_at\":\"1533295626391\",\"signature\":\"SsDoYq46L8fhYbU18R7iWGzYi0oEQaGGEEmOXtOKH6Q=\"}"
D, [2018-08-03T11:27:06.430136 #4] DEBUG -- request:
  url: "https://obfuscated--test--url.my.salesforce.com/services/data/v41.0/sobjects/Object_Name__c/Object_Custom_ID__c/ff97350a-af04-4c75-ab49-b0123489e1fd"
  method: :patch
  headers: {"User-Agent"=>"Faraday v0.12.2", "Content-Type"=>"application/json", "Authorization"=>"OAuth token"}
  body: "{\"Name\":\"Foo\", ...}"
D, [2018-08-03T11:27:06.831548 #4] DEBUG -- response:
  status: "204"
  headers: {"date"=>"Fri, 03 Aug 2018 11:27:06 GMT", "strict-transport-security"=>"max-age=31536002; includeSubDomains", "public-key-pins-report-only"=>"pin-sha256=\"9n0izTnSRF+W4W4JTq51avSXkWhQB8duS2bxVLfzXsY=\"; pin-sha256=\"5kJvNEMw0KjrCAu7eXY5HZdvyCS13BbA0VJG1RSP91w=\"; pin-sha256=\"njN4rRG+22dNXAi+yb8e3UMypgzPUPHlv4+foULwl1g=\"; max-age=86400; includeSubDomains; report-uri=\"https://calm-dawn-26291.herokuapp.com/hpkp-report/00Dq00000001BKzm\";", "expect-ct"=>"max-age=0; report-uri=\"https://calm-dawn-26291.herokuapp.com/Expect-CT-report/00Dq00000001BKzm\";", "x-robots-tag"=>"none", "cache-control"=>"no-cache,must-revalidate,max-age=0,no-store,private", "set-cookie"=>"BrowserId=C2pI8RbHQeiid8daXhEICA;Path=/;Domain=.salesforce.com;Expires=Tue, 02-Oct-2018 11:27:06 GMT;Max-Age=5184000", "expires"=>"Thu, 01 Jan 1970 00:00:00 GMT", "sforce-limit-info"=>"api-usage=12/123000", "connection"=>"close"}
  body: ""
```

This happens only when upserting an existing record.