### PR TITLE
Fix syntax error in Streaming API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ require 'faye'
 # Initialize a client with your username/password/oauth token/etc.
 client = Restforce.new(username: 'foo',
                        password: 'bar',
-                       security_token: 'security token'
+                       security_token: 'security token',
                        client_id: 'client_id',
                        client_secret: 'client_secret')
 


### PR DESCRIPTION
Just a simple fix for the main `Readme.md` in the Streaming API section.