### PR TITLE
Properly URL escape ids with spaces in them

### DIFF
--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'erb'
 require 'uri'
 require 'restforce/concerns/verbs'
 

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -377,7 +377,7 @@ module Restforce
               api_post "sobjects/#{sobject}/#{field}", attrs
             end
           else
-            api_patch "sobjects/#{sobject}/#{field}/#{CGI.escape(external_id)}", attrs
+            api_patch "sobjects/#{sobject}/#{field}/#{ERB::Util.url_encode(external_id)}", attrs
           end
 
         response.body.respond_to?(:fetch) ? response.body.fetch('id', true) : true
@@ -414,7 +414,7 @@ module Restforce
       # Returns true of the sobject was successfully deleted.
       # Raises an exception if an error is returned from Salesforce.
       def destroy!(sobject, id)
-        api_delete "sobjects/#{sobject}/#{CGI.escape(id)}"
+        api_delete "sobjects/#{sobject}/#{ERB::Util.url_encode(id)}"
         true
       end
 
@@ -428,9 +428,9 @@ module Restforce
       # Returns the Restforce::SObject sobject record.
       def find(sobject, id, field = nil)
         url = if field
-                "sobjects/#{sobject}/#{field}/#{CGI.escape(id)}"
+                "sobjects/#{sobject}/#{field}/#{ERB::Util.url_encode(id)}"
               else
-                "sobjects/#{sobject}/#{CGI.escape(id)}"
+                "sobjects/#{sobject}/#{ERB::Util.url_encode(id)}"
               end
         api_get(url).body
       end
@@ -446,9 +446,9 @@ module Restforce
       #
       def select(sobject, id, select, field = nil)
         path = if field
-                 "sobjects/#{sobject}/#{field}/#{CGI.escape(id)}"
+               "sobjects/#{sobject}/#{field}/#{ERB::Util.url_encode(id)}"
                else
-                 "sobjects/#{sobject}/#{CGI.escape(id)}"
+                 "sobjects/#{sobject}/#{ERB::Util.url_encode(id)}"
                end
 
         path = "#{path}?fields=#{select.join(',')}" if select&.any?

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -209,6 +209,24 @@ shared_examples_for Restforce::AbstractClient do
         end
       end
     end
+
+    context 'when created with a space in the id' do
+      requests 'sobjects/Account/External__c/foo%20bar',
+               method: :patch,
+               with_body: "{\"Name\":\"Foobar\"}",
+               fixture: 'sobject/upsert_created_success_response'
+
+      [:External__c, 'External__c', :external__c, 'external__c'].each do |key|
+        context "with #{key.inspect} as the external id" do
+          subject do
+            client.upsert!('Account', 'External__c', key => 'foo bar',
+                                                     :Name => 'Foobar')
+          end
+
+          it { should eq 'foo' }
+        end
+      end
+    end
   end
 
   describe '.destroy!' do
@@ -226,6 +244,13 @@ shared_examples_for Restforce::AbstractClient do
 
     context 'with success' do
       requests 'sobjects/Account/001D000000INjVe', method: :delete
+
+      it { should be_true }
+    end
+
+    context 'with a space in the id' do
+      subject(:destroy!) { client.destroy!('Account', '001D000000 INjVe') }
+      requests 'sobjects/Account/001D000000%20INjVe', method: :delete
 
       it { should be_true }
     end
@@ -266,6 +291,14 @@ shared_examples_for Restforce::AbstractClient do
       subject { client.find('Account', '1234', 'External_Field__c') }
       it { should be_a Hash }
     end
+
+    context 'with a space in an external id' do
+      requests 'sobjects/Account/External_Field__c/12%2034',
+               fixture: 'sobject/sobject_find_success_response'
+
+      subject { client.find('Account', '12 34', 'External_Field__c') }
+      it { should be_a Hash }
+    end
   end
 
   describe '.select' do
@@ -282,6 +315,14 @@ shared_examples_for Restforce::AbstractClient do
                  fixture: 'sobject/sobject_select_success_response'
 
         subject { client.select('Account', '1234', ['External_Field__c']) }
+        it { should be_a Hash }
+      end
+
+      context 'with a space in the id' do
+        requests 'sobjects/Account/12%2034',
+                 fixture: 'sobject/sobject_select_success_response'
+
+        subject { client.select('Account', '12 34', nil, nil) }
         it { should be_a Hash }
       end
     end


### PR DESCRIPTION
The client used to call CGI.escape on ids present in URLs.
This can lead to unexpected behavior where a space in an id
is encoded as a +, but is not decoded by Salesforce leading
to duplicate objects during upsert.

This commit replaces the CGI.escape calls with
ERG::Util.url_encode calls which encode space as %20.