### PR TITLE
Name exceptions for the error codes that might be returned from Salesforce.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Name exceptions for the error codes that might be returned from Salesforce.com (@boblail)
+
 ## 3.1.0 (Aug 16, 2018)
 
 * Add support for replaying missed messages when using the Salesforce Streaming API (@andreimaxim, @drteeth, @panozzaj)

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -45,6 +45,24 @@ module Restforce
   UnauthorizedError   = Class.new(Error)
   APIVersionError     = Class.new(Error)
 
+  # Inherit from Faraday::Error::ResourceNotFound for backwards-compatibility
+  # Consumers of this library that rescue and handle Faraday::Error::ResourceNotFound
+  # can continue to do so.
+  NotFoundError       = Class.new(Faraday::Error::ResourceNotFound)
+
+  # Inherit from Faraday::Error::ClientError for backwards-compatibility
+  # Consumers of this library that rescue and handle Faraday::Error::ClientError
+  # can continue to do so.
+  ResponseError       = Class.new(Faraday::Error::ClientError)
+  MatchesMultipleError= Class.new(ResponseError)
+  EntityTooLargeError = Class.new(ResponseError)
+
+  module ErrorCode
+    def self.const_missing(constant_name)
+      const_set constant_name, Class.new(ResponseError)
+    end
+  end
+
   class << self
     # Alias for Restforce::Data::Client.new
     #

--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -6,18 +6,22 @@ module Restforce
       @env = env
       case env[:status]
       when 300
-        raise Faraday::Error::ClientError.new("300: The external ID provided matches " \
-                                              "more than one record",
-                                              response_values)
+        raise Restforce::MatchesMultipleError.new(
+          "300: The external ID provided matches more than one record",
+          response_values
+        )
       when 401
         raise Restforce::UnauthorizedError, message
       when 404
-        raise Faraday::Error::ResourceNotFound, message
+        raise Restforce::NotFoundError, message
       when 413
-        raise Faraday::Error::ClientError.new("413: Request Entity Too Large",
-                                              response_values)
+        raise Restforce::EntityTooLargeError.new(
+          "413: Request Entity Too Large",
+          response_values
+        )
       when 400...600
-        raise Faraday::Error::ClientError.new(message, response_values)
+        klass = exception_class_for_error_code(body['errorCode'])
+        raise klass.new(message, response_values)
       end
     end
 
@@ -42,6 +46,15 @@ module Restforce
         headers: @env[:response_headers],
         body: @env[:body]
       }
+    end
+
+    ERROR_CODE_MATCHER = /\A[A-Z_]+\z/.freeze
+
+    def exception_class_for_error_code(error_code)
+      return Restforce::ResponseError unless ERROR_CODE_MATCHER.match?(error_code)
+
+      constant_name = error_code.split('_').map(&:capitalize).join.to_sym
+      constant = Restforce::ErrorCode.const_get(constant_name)
     end
   end
 end

--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -26,7 +26,10 @@ module Restforce
     end
 
     def message
-      "#{body['errorCode']}: #{body['message']}"
+      message = "#{body['errorCode']}: #{body['message']}"
+      message << "\nRESPONSE: #{JSON.dump(@env[:body])}"
+    rescue
+      message # if JSON.dump fails, return message without extra detail
     end
 
     def body

--- a/spec/unit/middleware/raise_error_spec.rb
+++ b/spec/unit/middleware/raise_error_spec.rb
@@ -13,34 +13,46 @@ describe Restforce::Middleware::RaiseError do
     context 'when the status code is 404' do
       let(:status) { 404 }
 
-      it "raises an error" do
-        expect { on_complete }.to raise_error Faraday::Error::ResourceNotFound,
+      it 'raises Restforce::NotFoundError' do
+        expect { on_complete }.to raise_error Restforce::NotFoundError,
                                               'INVALID_FIELD: error_message'
+      end
+
+      it 'raises an error that inherits from Faraday::Error::ResourceNotFound for backwards-compatibility' do
+        expect { on_complete }.to raise_error Faraday::Error::ResourceNotFound
       end
     end
 
     context 'when the status code is 300' do
       let(:status) { 300 }
 
-      it "raises an error" do
-        expect { on_complete }.to raise_error Faraday::Error::ClientError,
+      it 'raises Restforce::MatchesMultipleError' do
+        expect { on_complete }.to raise_error Restforce::MatchesMultipleError,
                                               /300: The external ID provided/
+      end
+
+      it 'raises an error that inherits from Faraday::Error::ClientError for backwards-compatibility' do
+        expect { on_complete }.to raise_error Faraday::Error::ClientError
       end
     end
 
     context 'when the status code is 400' do
       let(:status) { 400 }
 
-      it "raises an error" do
-        expect { on_complete }.to raise_error Faraday::Error::ClientError,
+      it "raises an error derived from the response's errorCode" do
+        expect { on_complete }.to raise_error Restforce::ErrorCode::InvalidField,
                                               'INVALID_FIELD: error_message'
+      end
+
+      it 'raises an error that inherits from Faraday::Error::ClientError for backwards-compatibility' do
+        expect { on_complete }.to raise_error Faraday::Error::ClientError
       end
     end
 
     context 'when the status code is 401' do
       let(:status) { 401 }
 
-      it "raises an error" do
+      it 'raises Restforce::UnauthorizedError' do
         expect { on_complete }.to raise_error Restforce::UnauthorizedError,
                                               'INVALID_FIELD: error_message'
       end
@@ -49,17 +61,26 @@ describe Restforce::Middleware::RaiseError do
     context 'when the status code is 413' do
       let(:status) { 413 }
 
-      it "raises an error" do
-        expect { on_complete }.to raise_error Faraday::Error::ClientError,
+      it 'raises Restforce::EntityTooLargeError' do
+        expect { on_complete }.to raise_error Restforce::EntityTooLargeError,
                                               '413: Request Entity Too Large'
+      end
+
+      it 'raises an error that inherits from Faraday::Error::ClientError for backwards-compatibility' do
+        expect { on_complete }.to raise_error Faraday::Error::ClientError
       end
     end
 
     context 'when status is 400+ and body is a string' do
       let(:body)   { 'An error occured' }
-      let(:status) { 404 }
+      let(:status) { 400 }
 
-      it 'raises an error with a non-existing error code' do
+      it 'raises a generic Restforce::ResponseError' do
+        expect { on_complete }.to raise_error Restforce::ResponseError,
+                                              "(error code missing): #{body}"
+      end
+
+      it 'raises an error that inherits from Faraday::Error::ClientError for backwards-compatibility' do
         expect { on_complete }.to raise_error Faraday::Error::ClientError,
                                               "(error code missing): #{body}"
       end


### PR DESCRIPTION
Currently, Restforce raises `Faraday::Error::ClientError` for nearly every kind of error that can occur. Errors like `INVALID_OPERATION` are problems in client code that require human intervention to fix while errors like `REQUEST_LIMIT_EXCEEDED` or `SERVER_UNAVAILABLE` are transient errors that could be handled programmatically by queuing work and retrying later.

This pull request unwraps the various error responses that a client may receive from Salesforce so that API consumers can more easily differentiate errors.