### PR TITLE
Add support for platform events, CDC, generic events, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,8 +513,10 @@ client.get('/services/apexrest/FieldCase', company: 'GenePoint')
 
 ### Streaming
 
-Restforce supports the [Streaming API](http://wiki.developerforce.com/page/Getting_Started_with_the_Force.com_Streaming_API), and makes implementing
-pub/sub with Salesforce a trivial task:
+Restforce supports the [Streaming API](https://trailhead.salesforce.com/en/content/learn/modules/api_basics/api_basics_streaming), and makes implementing
+pub/sub with Salesforce a trivial task.
+
+Here is an example of creating and subscribing to a `PushTopic`:
 
 ```ruby
 # Restforce uses faye as the underlying implementation for CometD.
@@ -538,7 +540,7 @@ client.create!('PushTopic',
 
 EM.run do
   # Subscribe to the PushTopic.
-  client.subscribe 'AllAccounts' do |message|
+  client.subscription '/topic/AllAccounts' do |message|
     puts message.inspect
   end
 end
@@ -559,7 +561,7 @@ that event ID:
 ```ruby
 EM.run {
   # Subscribe to the PushTopic.
-  client.subscribe 'AllAccounts', replay: 10 do |message|
+  client.subscription '/topic/AllAccounts', replay: 10 do |message|
     puts message.inspect
   end
 }
@@ -633,7 +635,7 @@ of the subscription:
 EM.run {
   # Subscribe to the PushTopic and use the custom replay handler to store any
   # received replay ID.
-  client.subscribe 'AllAccounts', replay: SimpleReplayHandler.new do |message|
+  client.subscription '/topic/AllAccounts', replay: SimpleReplayHandler.new do |message|
     puts message.inspect
   end
 }

--- a/spec/unit/concerns/streaming_spec.rb
+++ b/spec/unit/concerns/streaming_spec.rb
@@ -4,18 +4,19 @@ require 'spec_helper'
 
 describe Restforce::Concerns::Streaming, event_machine: true do
   describe '.subscribe' do
-    let(:channels)        { %w[channel1 channel2] }
-    let(:topics)          { channels.map { |c| "/topic/#{c}" } }
+    let(:channels) do
+      ['/topic/topic1', '/event/MyCustomEvent__e', '/data/ChangeEvents']
+    end
     let(:subscribe_block) { lambda { 'subscribe' } }
     let(:faye_double)     { double('Faye') }
 
     it 'subscribes to the topics with faye' do
       faye_double.
         should_receive(:subscribe).
-        with(topics, &subscribe_block)
+        with(channels, &subscribe_block)
       client.stub faye: faye_double
 
-      client.subscribe(channels, &subscribe_block)
+      client.subscription(channels, &subscribe_block)
     end
 
     context "replay_handlers" do
@@ -25,23 +26,50 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       }
 
       it 'registers nil handlers when no replay option is given' do
-        client.subscribe(channels, &subscribe_block)
-        client.replay_handlers.should eq('channel1' => nil, 'channel2' => nil)
+        client.subscription(channels, &subscribe_block)
+        client.replay_handlers.should eq(
+          '/topic/topic1' => nil,
+          '/event/MyCustomEvent__e' => nil,
+          '/data/ChangeEvents' => nil
+        )
       end
 
       it 'registers a replay_handler for each channel given' do
-        client.subscribe(channels, replay: -2, &subscribe_block)
-        client.replay_handlers.should eq('channel1' => -2, 'channel2' => -2)
+        client.subscription(channels, replay: -2, &subscribe_block)
+        client.replay_handlers.should eq(
+          '/topic/topic1' => -2,
+          '/event/MyCustomEvent__e' => -2,
+          '/data/ChangeEvents' => -2
+        )
       end
 
       it 'replaces earlier handlers in subsequent calls' do
-        client.subscribe(%w[channel1 channel2], replay: 2, &subscribe_block)
-        client.subscribe(%w[channel2 channel3], replay: 3, &subscribe_block)
-        client.replay_handlers.should eq(
-          'channel1' => 2,
-          'channel2' => 3,
-          'channel3' => 3
+        client.subscription(
+          ['/topic/channel1', '/topic/channel2'],
+          replay: 2,
+          &subscribe_block
         )
+        client.subscription(
+          ['/topic/channel2', '/topic/channel3'],
+          replay: 3,
+          &subscribe_block
+        )
+
+        client.replay_handlers.should eq(
+          '/topic/channel1' => 2,
+          '/topic/channel2' => 3,
+          '/topic/channel3' => 3
+        )
+      end
+
+      context 'backwards compatibility' do
+        it 'it assumes channels are push topics' do
+          client.subscribe(%w[channel1 channel2], replay: -2, &subscribe_block)
+          client.replay_handlers.should eq(
+            '/topic/channel1' => -2,
+            '/topic/channel2' => -2
+          )
+        end
       end
     end
   end
@@ -87,41 +115,41 @@ describe Restforce::Concerns::Streaming, event_machine: true do
     let(:extension) { Restforce::Concerns::Streaming::ReplayExtension.new(handlers) }
 
     it 'sends nil without a specified handler' do
-      output = subscribe(extension, to: "channel1")
+      output = subscribe(extension, to: "/topic/channel1")
       read_replay(output).should eq('/topic/channel1' => nil)
     end
 
     it 'with a scalar replay id' do
-      handlers['channel1'] = -2
-      output = subscribe(extension, to: "channel1")
+      handlers['/topic/channel1'] = -2
+      output = subscribe(extension, to: "/topic/channel1")
       read_replay(output).should eq('/topic/channel1' => -2)
     end
 
     it 'with a hash' do
-      hash_handler = { 'channel1' => -1, 'channel2' => -2 }
+      hash_handler = { '/topic/channel1' => -1, '/topic/channel2' => -2 }
 
-      handlers['channel1'] = hash_handler
-      handlers['channel2'] = hash_handler
+      handlers['/topic/channel1'] = hash_handler
+      handlers['/topic/channel2'] = hash_handler
 
-      output = subscribe(extension, to: "channel1")
+      output = subscribe(extension, to: "/topic/channel1")
       read_replay(output).should eq('/topic/channel1' => -1)
 
-      output = subscribe(extension, to: "channel2")
+      output = subscribe(extension, to: "/topic/channel2")
       read_replay(output).should eq('/topic/channel2' => -2)
     end
 
     it 'with an object' do
       custom_handler = double('custom_handler')
       custom_handler.should_receive(:[]).and_return(123)
-      handlers['channel1'] = custom_handler
+      handlers['/topic/channel1'] = custom_handler
 
-      output = subscribe(extension, to: "channel1")
+      output = subscribe(extension, to: "/topic/channel1")
       read_replay(output).should eq('/topic/channel1' => 123)
     end
 
     it 'remembers the last replayId' do
-      handler = { 'channel1' => 41 }
-      handlers['channel1'] = handler
+      handler = { '/topic/channel1' => 41 }
+      handlers['/topic/channel1'] = handler
       message = {
         'channel' => '/topic/channel1',
         'data' => {
@@ -130,12 +158,12 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       }
 
       extension.incoming(message, ->(m) {})
-      handler.should eq('channel1' => 42)
+      handler.should eq('/topic/channel1' => 42)
     end
 
     it 'when an incoming message has no replayId' do
-      handler = { 'channel1' => 41 }
-      handlers['channel1'] = handler
+      handler = { '/topic/channel1' => 41 }
+      handlers['/topic/channel1'] = handler
 
       message = {
         'channel' => '/topic/channel1',
@@ -143,7 +171,7 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       }
 
       extension.incoming(message, ->(m) {})
-      handler.should eq('channel1' => 41)
+      handler.should eq('/topic/channel1' => 41)
     end
 
     private
@@ -152,7 +180,7 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       output = nil
       message = {
         'channel' => '/meta/subscribe',
-        'subscription' => "/topic/#{options[:to]}"
+        'subscription' => options[:to]
       }
       extension.outgoing(message, ->(m) {
         output = m


### PR DESCRIPTION
Unfortunately the streaming concern currently hardcodes `/topic/` in the channel name, which limits the number of use-cases it can be used for, especially now that Salesforce have [a number of other ways](https://trineo.com/blog/2019/04/push-vs-cdc) to publish cometD messages.