### PR TITLE
Fix rspec warning during test runs

### DIFF
--- a/spec/unit/sobject_spec.rb
+++ b/spec/unit/sobject_spec.rb
@@ -45,13 +45,10 @@ describe Restforce::SObject do
     destroy: :destroy,
     destroy!: :destroy! }.each do |method, receiver|
     describe ".#{method}" do
-      subject(:send_method) { sobject.send(method) }
+      subject(:send_method) { lambda { sobject.send(method) } }
 
       context 'when an Id was not queried' do
-        it "raises an error" do
-          expect { send_method }.to raise_error ArgumentError,
-                                                /need to query the Id for the record/
-        end
+        it { should raise_error ArgumentError, /need to query the Id for the record/ }
       end
 
       context 'when an Id is present' do


### PR DESCRIPTION
When running the test suite, rspec spits out the following warning:

```
`raise_error` was called with non-proc object nil
```

This is happening whenever `raise_error` is used with a non-block subject, because then, the code is executed before the expectation was set up and therefore it may yield unexpected results.

This change wraps the subject in a `lambda` so that the warning goes away and the spec works as expected. I also refactored a related spec, because due to the improved subject set up it may now become a bit simpler.