### PR TITLE
Fix nil attributes error

### DIFF
--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -28,6 +28,8 @@ module Restforce
           # of sobject records.
           Restforce::Collection
         elsif val.key? 'attributes'
+          return Restforce::SObject unless val['attributes']
+
           case (val['attributes']['type'])
           when "Attachment"
             Restforce::Attachment

--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -28,9 +28,7 @@ module Restforce
           # of sobject records.
           Restforce::Collection
         elsif val.key? 'attributes'
-          return Restforce::SObject unless val['attributes']
-
-          case (val['attributes']['type'])
+          case val.dig('attributes', 'type')
           when "Attachment"
             Restforce::Attachment
           when "Document"

--- a/spec/unit/mash_spec.rb
+++ b/spec/unit/mash_spec.rb
@@ -33,6 +33,11 @@ describe Restforce::Mash do
         let(:input) { { 'attributes' => { 'type' => 'Document' } } }
         it { should eq Restforce::Document }
       end
+
+      context 'when the attributes value is nil' do
+        let(:input) { { 'attributes' => nil } }
+        it { should eq Restforce::SObject }
+      end
     end
 
     context 'else' do


### PR DESCRIPTION
This fixes an issue in mash when the `attributes` key is present but the value is nil. Currently when this happens it fails on line 31: `case (val['attributes']['type'])` with:
```
NoMethodError: undefined method `[]' for nil:NilClass
```
Now when this happens we just return `Restforce::SObject`.