### PR TITLE
Fallback to building a Restforce::Mash if the attributes hash does not contain a type

### DIFF
--- a/lib/restforce/mash.rb
+++ b/lib/restforce/mash.rb
@@ -27,7 +27,7 @@ module Restforce
           # When the hash has a records key, it should be considered a collection
           # of sobject records.
           Restforce::Collection
-        elsif val.key? 'attributes'
+        elsif val.dig('attributes', 'type')
           case (val['attributes']['type'])
           when "Attachment"
             Restforce::Attachment

--- a/spec/unit/mash_spec.rb
+++ b/spec/unit/mash_spec.rb
@@ -33,6 +33,11 @@ describe Restforce::Mash do
         let(:input) { { 'attributes' => { 'type' => 'Document' } } }
         it { should eq Restforce::Document }
       end
+
+      context 'when the hash has an "attributes" key without a type' do
+        let(:input) { { 'attributes' => {} } }
+        it { should eq Restforce::Mash }
+      end
     end
 
     context 'else' do


### PR DESCRIPTION
When trying to make arbitrary API calls to, for example, the `/ui-api/object-info/<object>/picklist-values/` endpoint, the response contains an attributes key but no type key, which was causing the following:

```
NoMethodError: undefined method `[]' for nil:NilClass
from .../restforce-4.2.1/lib/restforce/mash.rb:32:in `klass'
```

This patch ensures that there is a type key inside of the attributes hash, otherwise it just falls back to Restforce::Mash.