### PR TITLE
Adds ability to opt in to caching on a per-request basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,22 @@ client.without_caching do
 end
 ```
 
+If you prefer to opt in to caching on a per-request, you can do so by using .with_caching and
+setting the use_cache config option to false:
+
+```ruby
+Restforce.configure do |config|
+  config.cache = Rails.cache
+  config.use_cache = false
+end
+```
+
+```ruby
+client.with_caching do
+  client.query('select Id from Account')
+end
+```
+
 Caching is done on based on your authentication credentials, so cached responses will not be shared between different Salesforce logins.
 
 * * *

--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ end
 ```
 
 If you prefer to opt in to caching on a per-request, you can do so by using .with_caching and
-setting the use_cache config option to false:
+setting the `use_cache` config option to false:
 
 ```ruby
 Restforce.configure do |config|
@@ -704,7 +704,7 @@ client.with_caching do
 end
 ```
 
-Caching is done on based on your authentication credentials, so cached responses will not be shared between different Salesforce logins.
+Caching is done based on your authentication credentials, so cached responses will not be shared between different Salesforce logins.
 
 * * *
 

--- a/lib/restforce/concerns/caching.rb
+++ b/lib/restforce/concerns/caching.rb
@@ -15,6 +15,13 @@ module Restforce
         options.delete(:use_cache)
       end
 
+      def with_caching
+        options[:use_cache] = true
+        yield
+      ensure
+        options[:use_cache] = false
+      end
+
       private
 
       # Internal: Cache to use for the caching middleware

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -156,6 +156,9 @@ module Restforce
     # Set a log level for logging when Restforce.log is set to true, defaulting to :debug
     option :log_level, default: :debug
 
+    # Set use_cache to false to opt in to caching with client.with_caching
+    option :use_cache, default: true
+
     def options
       self.class.options
     end

--- a/lib/restforce/middleware/caching.rb
+++ b/lib/restforce/middleware/caching.rb
@@ -18,7 +18,7 @@ module Restforce
     end
 
     def use_cache?
-      @options.fetch(:use_cache, true)
+      @options[:use_cache]
     end
 
     def hashed_auth_header(env)

--- a/spec/unit/concerns/caching_spec.rb
+++ b/spec/unit/concerns/caching_spec.rb
@@ -28,4 +28,30 @@ describe Restforce::Concerns::Caching do
       end
     end
   end
+
+  describe '.with_caching' do
+    let(:options) { double('Options') }
+
+    before do
+      client.stub options: options
+    end
+
+    it 'runs the block with caching enabled' do
+      options.should_receive(:[]=).with(:use_cache, true)
+      options.should_receive(:[]=).with(:use_cache, false)
+      expect { |b| client.with_caching(&b) }.to yield_control
+    end
+
+    context 'when an exception is raised' do
+      it 'ensures the :use_cache is set to false' do
+        options.should_receive(:[]=).with(:use_cache, true)
+        options.should_receive(:[]=).with(:use_cache, false)
+        expect {
+          client.with_caching do
+            raise 'Foo'
+          end
+        }.to raise_error 'Foo'
+      end
+    end
+  end
 end


### PR DESCRIPTION
I would like to take advantage of Restforce's caching feature but would prefer to opt in as I make changes to the code base. This adds the ability to opt in to caching on a per-request basis similar to `.without_caching` method opts out on a per-request basis. 

The changes I made here seemed to require the least amount of systematic alterations. It adds a method and makes a private config public with a default. The one negative I see to this option is that because of the way things are setup in `Restorce::Concerns::Connection`, all requests will actually be cached. Only those within `.with_caching` will not expire the cache first, forcing a fresh request, thus accomplishing my intent.

It seems like if we wanted to only write to the cache in `.with_caching` or likewise not write to the cache in `.without_caching` as mentioned in https://github.com/restforce/restforce/issues/501 then we would need to build the Restforce::Concerns::Connection `@connection` each time instead of memoizing it, and have an option to include middleware in addition to `if cache`. See line 44 from Restforce::Concerns::Connection below:

```ruby
          builder.use Restforce::Middleware::Caching, cache, options if cache
```

There may be more to this than I'm seeing, but I thought I would go ahead and make this PR in case people thought it would be useful. I certainly understand if you think its out of scope and I'll go a different route.