### PR TITLE
Remove 'json' gem dependency

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 1.0']
 
-  gem.add_dependency 'json', '>= 1.7.5'
   gem.add_dependency 'jwt', ['>= 1.5.6']
 
   gem.add_dependency 'hashie', '>= 1.2.0', '< 5.0'


### PR DESCRIPTION
JSON has been in the stdlib since 1.9, there's no need to declare any dependencies at all. Just `require 'json'`.

Since it is generally a good idea to reduce the number of dependencies this Pull Request aims to remove the superfluous dependency on the `json` gem. 