### PR TITLE
Update faraday and faraday_middleware dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '~> 0.17.0'
+gem 'faraday', '~> 1.0.0'
 gem 'jruby-openssl', platforms: :jruby
 gem 'jwt'
 gem 'rake'

--- a/lib/restforce/upload_io.rb
+++ b/lib/restforce/upload_io.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Restforce
-  UploadIO = Faraday::UploadIO
+  UploadIO = Faraday::FilePart
 end
 
 require 'restforce/patches/parts' unless Parts::Part.method(:new).arity.abs == 4

--- a/lib/restforce/upload_io.rb
+++ b/lib/restforce/upload_io.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday/upload_io'
-
 module Restforce
   UploadIO = Faraday::UploadIO
 end

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
-  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 1.0']
+  gem.add_dependency 'faraday', '>= 0.9.0', '<= 2.0'
+  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']
 
   gem.add_dependency 'json', '>= 1.7.5'
   gem.add_dependency 'jwt', ['>= 1.5.6']

--- a/spec/unit/concerns/connection_spec.rb
+++ b/spec/unit/concerns/connection_spec.rb
@@ -75,7 +75,7 @@ describe Restforce::Concerns::Connection do
 
       it "must always be used last before the Faraday Adapter" do
         client.middleware.handlers.reverse.index(Restforce::Middleware::Logger).
-          should eq 1
+          should eq 0
       end
     end
   end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -56,10 +56,8 @@ describe Restforce::Middleware::Authentication do
           Restforce.stub log?: false
         end
 
-        its(:handlers) {
-          should include FaradayMiddleware::ParseJson,
-                         Faraday::Adapter::NetHttp
-        }
+        its(:adapter) { should eq(Faraday::Adapter::NetHttp) }
+        its(:handlers) { should include FaradayMiddleware::ParseJson }
         its(:handlers) { should_not include Restforce::Middleware::Logger }
       end
 
@@ -68,9 +66,10 @@ describe Restforce::Middleware::Authentication do
           Restforce.stub log?: true
         end
 
+        its(:adapter) { should eq(Faraday::Adapter::NetHttp) }
         its(:handlers) {
           should include FaradayMiddleware::ParseJson,
-                         Restforce::Middleware::Logger, Faraday::Adapter::NetHttp
+                         Restforce::Middleware::Logger
         }
       end
 
@@ -79,9 +78,8 @@ describe Restforce::Middleware::Authentication do
           options[:adapter] = :typhoeus
         end
 
-        its(:handlers) {
-          should include FaradayMiddleware::ParseJson, Faraday::Adapter::Typhoeus
-        }
+        its(:adapter) { should eq(Faraday::Adapter::Typhoeus) }
+        its(:handlers) { should include FaradayMiddleware::ParseJson }
       end
     end
 
@@ -94,7 +92,9 @@ describe Restforce::Middleware::Authentication do
     context 'when response.body is present' do
       let(:response) {
         Faraday::Response.new(
-          body: { 'error' => 'error', 'error_description' => 'description' },
+          response_body: {
+            'error' => 'error', 'error_description' => 'description'
+          },
           status: 401
         )
       }


### PR DESCRIPTION
Update of `faraday` and `faraday_middleware` dependencies.
With this update I fixed the specs that broke.

These updates are very important as many other gems do not work alongside restforce.

Ex: `elasticsearch`, '~> 7.6.0'