### PR TITLE
Add empty? to Restforce::Collection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ Some things that will increase the chance that your pull request is accepted:
 * Write tests.
 * Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
-*Adapted from [factory_girl_rails's CONTRIBUTING.md](https://github.com/thoughtbot/factory_girl_rails/blob/master/CONTRIBUTING.md).*
+*Adapted from [factory_bot_rails's CONTRIBUTING.md](https://github.com/thoughtbot/factory_bot_rails/blob/master/CONTRIBUTING.md).*

--- a/lib/restforce/collection.rb
+++ b/lib/restforce/collection.rb
@@ -33,6 +33,11 @@ module Restforce
     end
     alias length size
 
+    # Returns true if the size of the Collection is zero.
+    def empty?
+      size.zero?
+    end
+
     # Return array of the elements on the current page
     def current_page
       first(@raw_page['records'].size)

--- a/spec/unit/collection_spec.rb
+++ b/spec/unit/collection_spec.rb
@@ -62,4 +62,22 @@ describe Restforce::Collection do
       end
     end
   end
+
+  describe '#empty?' do
+    subject(:empty?) do
+      described_class.new(JSON.parse(fixture(sobject_fixture)), client).empty?
+    end
+
+    context 'with size 1' do
+      let(:sobject_fixture) { 'sobject/query_success_response' }
+
+      it { should be_false }
+    end
+
+    context 'with size 0' do
+      let(:sobject_fixture) { 'sobject/query_empty_response' }
+
+      it { should be_true }
+    end
+  end
 end


### PR DESCRIPTION
Also fixes a link in CONTRIBUTING.md.

The `empty?` method exists on many Ruby collections like `Array`, `Hash`, and `Set`.  But it isn't part of `Enumerable` presumably because not every iterator knows the full length of the collection, iterating might be destructive, iterating might be expensive, or the enumeration could be infinite.

But `Restforce::Collection` knows the length of the collection without having to make another API request.  So I think it would be nice to have `empty?` to more closely match some of the other Ruby collection interfaces.