### PR TITLE
Add support for faraday 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '~> 0.17.0'
 gem 'jruby-openssl', platforms: :jruby
 gem 'jwt'
 gem 'rake'

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ Using the new [Blob Data](http://www.salesforce.com/us/developer/docs/api_rest/C
 client.create('Document', FolderId: '00lE0000000FJ6H',
                           Description: 'Document test',
                           Name: 'My image',
-                          Body: Restforce::UploadIO.new(File.expand_path('image.jpg', __FILE__), 'image/jpeg')
+                          Body: Restforce::FilePart.new(File.expand_path('image.jpg', __FILE__), 'image/jpeg')
 ```
 
 Using base64 encoded data (37.5mb limit):

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -15,7 +15,8 @@ module Restforce
   autoload :Middleware,     'restforce/middleware'
   autoload :Attachment,     'restforce/attachment'
   autoload :Document,       'restforce/document'
-  autoload :UploadIO,       'restforce/upload_io'
+  autoload :FilePart,       'restforce/file_part'
+  autoload :UploadIO,       'restforce/file_part' # Deprecated
   autoload :SObject,        'restforce/sobject'
   autoload :Client,         'restforce/client'
   autoload :Mash,           'restforce/mash'

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -510,7 +510,7 @@ module Restforce
 
       # Internal: Errors that should be rescued from in non-bang methods
       def exceptions
-        [Faraday::ClientError]
+        [Faraday::Error]
       end
     end
   end

--- a/lib/restforce/file_part.rb
+++ b/lib/restforce/file_part.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+begin
+  require 'faraday/file_part'
+rescue LoadError
+  require 'faraday/upload_io'
+end
+
+module Restforce
+  if defined?(::Faraday::FilePart)
+    FilePart = Faraday::FilePart
+
+    # Deprecated
+    UploadIO = Faraday::FilePart
+  else
+    # Handle pre-1.0 versions of faraday
+    FilePart = Faraday::UploadIO
+    UploadIO = Faraday::UploadIO
+  end
+end
+
+# This patch is only needed with multipart-post < 2.0.0
+# 2.0.0 was released in 2013.
+require 'restforce/patches/parts' unless Parts::Part.method(:new).arity.abs == 4

--- a/lib/restforce/upload_io.rb
+++ b/lib/restforce/upload_io.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'faraday/upload_io'
-
-module Restforce
-  UploadIO = Faraday::UploadIO
-end
-
-require 'restforce/patches/parts' unless Parts::Part.method(:new).arity.abs == 4

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
-  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 1.0']
+  gem.add_dependency 'faraday', '<= 2.0', '>= 0.9.0'
+  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']
 
   gem.add_dependency 'json', '>= 1.7.5'
   gem.add_dependency 'jwt', ['>= 1.5.6']

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -95,13 +95,25 @@ shared_examples_for Restforce::AbstractClient do
 
       subject do
         client.create('Account', Name: 'Foobar',
-                                 Blob: Restforce::UploadIO.new(
+                                 Blob: Restforce::FilePart.new(
                                    File.expand_path('../fixtures/blob.jpg', __dir__),
                                    'image/jpeg'
                                  ))
       end
 
       it { should eq 'some_id' }
+
+      context 'with deprecated UploadIO' do
+        subject do
+          client.create('Account', Name: 'Foobar',
+                        Blob: Restforce::UploadIO.new(
+                          File.expand_path('../fixtures/blob.jpg', __dir__),
+                          'image/jpeg'
+          ))
+        end
+
+        it { should eq 'some_id' }
+      end
     end
   end
 

--- a/spec/integration/abstract_client_spec.rb
+++ b/spec/integration/abstract_client_spec.rb
@@ -109,7 +109,7 @@ shared_examples_for Restforce::AbstractClient do
                         Blob: Restforce::UploadIO.new(
                           File.expand_path('../fixtures/blob.jpg', __dir__),
                           'image/jpeg'
-          ))
+                        ))
         end
 
         it { should eq 'some_id' }

--- a/spec/unit/concerns/connection_spec.rb
+++ b/spec/unit/concerns/connection_spec.rb
@@ -73,9 +73,9 @@ describe Restforce::Concerns::Connection do
         Restforce.stub(log?: true)
       end
 
-      it "must always be used last before the Faraday Adapter" do
+      it "must always be used as the last handler" do
         client.middleware.handlers.reverse.index(Restforce::Middleware::Logger).
-          should eq 1
+          should eq 0
       end
     end
   end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -57,10 +57,10 @@ describe Restforce::Middleware::Authentication do
         end
 
         its(:handlers) {
-          should include FaradayMiddleware::ParseJson,
-                         Faraday::Adapter::NetHttp
+          should include FaradayMiddleware::ParseJson
         }
         its(:handlers) { should_not include Restforce::Middleware::Logger }
+        its(:adapter) { should eq Faraday::Adapter::NetHttp }
       end
 
       context 'with logging enabled' do
@@ -70,8 +70,9 @@ describe Restforce::Middleware::Authentication do
 
         its(:handlers) {
           should include FaradayMiddleware::ParseJson,
-                         Restforce::Middleware::Logger, Faraday::Adapter::NetHttp
+                         Restforce::Middleware::Logger
         }
+        its(:adapter) { should eq Faraday::Adapter::NetHttp }
       end
 
       context 'with specified adapter' do
@@ -80,8 +81,9 @@ describe Restforce::Middleware::Authentication do
         end
 
         its(:handlers) {
-          should include FaradayMiddleware::ParseJson, Faraday::Adapter::Typhoeus
+          should include FaradayMiddleware::ParseJson
         }
+        its(:adapter) { should eq Faraday::Adapter::Typhoeus }
       end
     end
 
@@ -94,7 +96,7 @@ describe Restforce::Middleware::Authentication do
     context 'when response.body is present' do
       let(:response) {
         Faraday::Response.new(
-          body: { 'error' => 'error', 'error_description' => 'description' },
+          response_body: { 'error' => 'error', 'error_description' => 'description' },
           status: 401
         )
       }


### PR DESCRIPTION
I followed: https://github.com/lostisland/faraday/blob/master/UPGRADING.md

I also looked at the differences between older versions (https://github.com/lostisland/faraday/blob/v0.15.4/lib/faraday/error.rb) and the latest version (https://github.com/lostisland/faraday/blob/v1.0.1/lib/faraday/error.rb) to see if there was common behaviour we could exploit. That's where rescuing `Faraday::Error` came from.

Fixes #530
Closes #526
Closes #544 