### PR TITLE
Drop support for Ruby 2.4 and update build matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,28 +34,23 @@ references:
         destination: test-results
 
 jobs:
-  build-ruby270:
+  build-ruby271:
     docker:
-       - image: circleci/ruby:2.7.0
+       - image: circleci/ruby:2.7.1
     steps: *steps
-  build-ruby265:
+  build-ruby266:
     docker:
-       - image: circleci/ruby:2.6.5
+       - image: circleci/ruby:2.6.6
     steps: *steps
-  build-ruby257:
+  build-ruby258:
     docker:
-       - image: circleci/ruby:2.5.7
-    steps: *steps
-  build-ruby249:
-    docker:
-       - image: circleci/ruby:2.4.9
+       - image: circleci/ruby:2.5.8
     steps: *steps
 
 workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby270
-      - build-ruby265
-      - build-ruby257
-      - build-ruby249
+      - build-ruby271
+      - build-ruby266
+      - build-ruby258

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   Exclude:
     - .*/**/*
     - vendor/**/*
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Limit lines to 90 characters.
 Layout/LineLength:

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
     'changelog_uri'   => 'https://github.com/restforce/restforce/blob/master/CHANGELOG.md'
   }
 
-  gem.required_ruby_version = '>= 2.4'
+  gem.required_ruby_version = '>= 2.5'
 
   gem.add_dependency 'faraday', '<= 2.0', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']


### PR DESCRIPTION
This PR drops support for Ruby 2.4, since it has reached end of life, and updates our CircleCI testing matrix so we drop testing against 2.4 and use the latest patch versions of 2.5, 2.6 and 2.7.

This will be released as a major version since it breaks Ruby compatibility, and will require README updates to make that clear.