### PR TITLE
Handle `REQUEST_LIMIT_EXCEEDED` and `SERVER_UNAVAILABLE` errors from Salesforce

### DIFF
--- a/lib/restforce/error_code.rb
+++ b/lib/restforce/error_code.rb
@@ -170,6 +170,7 @@ module Restforce
     class RequestRunningTooLong < ResponseError; end
     class RequiredFieldMissing < ResponseError; end
     class SelfReferenceFromTrigger < ResponseError; end
+    class ServerUnavailable < ResponseError; end
     class ShareNeededForChildOwner < ResponseError; end
     class SingleEmailLimitExceeded < ResponseError; end
     class StandardPriceNotDefined < ResponseError; end
@@ -362,6 +363,7 @@ module Restforce
       "REQUEST_RUNNING_TOO_LONG" => RequestRunningTooLong,
       "REQUIRED_FIELD_MISSING" => RequiredFieldMissing,
       "SELF_REFERENCE_FROM_TRIGGER" => SelfReferenceFromTrigger,
+      "SERVER_UNAVAILABLE" => ServerUnavailable,
       "SHARE_NEEDED_FOR_CHILD_OWNER" => ShareNeededForChildOwner,
       "SINGLE_EMAIL_LIMIT_EXCEEDED" => SingleEmailLimitExceeded,
       "STANDARD_PRICE_NOT_DEFINED" => StandardPriceNotDefined,

--- a/lib/restforce/error_code.rb
+++ b/lib/restforce/error_code.rb
@@ -167,6 +167,7 @@ module Restforce
     class PortalUserAlreadyExistsForContact < ResponseError; end
     class PrivateContactOnAsset < ResponseError; end
     class RecordInUseByWorkflow < ResponseError; end
+    class RequestLimitExceeded < ResponseError; end
     class RequestRunningTooLong < ResponseError; end
     class RequiredFieldMissing < ResponseError; end
     class SelfReferenceFromTrigger < ResponseError; end
@@ -360,6 +361,7 @@ module Restforce
       "PORTAL_USER_ALREADY_EXISTS_FOR_CONTACT" => PortalUserAlreadyExistsForContact,
       "PRIVATE_CONTACT_ON_ASSET" => PrivateContactOnAsset,
       "RECORD_IN_USE_BY_WORKFLOW" => RecordInUseByWorkflow,
+      "REQUEST_LIMIT_EXCEEDED" => RequestLimitExceeded,
       "REQUEST_RUNNING_TOO_LONG" => RequestRunningTooLong,
       "REQUIRED_FIELD_MISSING" => RequiredFieldMissing,
       "SELF_REFERENCE_FROM_TRIGGER" => SelfReferenceFromTrigger,


### PR DESCRIPTION
Fixes #567 and #568. Thanks @wkirby!