### PR TITLE
Allow Faraday versions up to, but not including, v1.1 to be used with Restforce 4.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '~> 0.17.0'
+gem 'faraday', '~> 1.0.1'
 gem 'jruby-openssl', platforms: :jruby
 gem 'jwt'
 gem 'rake'

--- a/lib/restforce/upload_io.rb
+++ b/lib/restforce/upload_io.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
-require 'faraday/upload_io'
+if Faraday::VERSION =~ /^0\./
+  require 'faraday/upload_io'
+else
+  require 'faraday/file_part'
+end
 
 module Restforce
   UploadIO = Faraday::UploadIO

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.4'
 
-  gem.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
-  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 1.0']
+  gem.add_dependency 'faraday', '< 1.1', '>= 0.9.0'
+  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '< 1.1']
 
   gem.add_dependency 'json', '>= 1.7.5'
   gem.add_dependency 'jwt', ['>= 1.5.6']


### PR DESCRIPTION
Addresses #566.