### PR TITLE
Allow passing an option to client.subscription which will return both channel and message in the callback block

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,32 @@ end
 Boom, you're now receiving push notifications when Accounts are
 created/updated.
 
+#### Receiving events from more than one channel
+
+If you want to listen to events from more than one channel, you can pass an array of channels to the client.subscription call:
+
+```
+EM.run do
+  # Subscribe to multiple PushTopics.
+  client.subscription ['/topic/AllAccounts', '/topic/AllUsers'] do |message|
+    puts message.inspect
+  end
+end
+```
+
+The only downside to this approach is that you will not necessarily know which channel the message came from. However, if you add the `with_channel:` option to the subscription call, the callback will provide the channel and message:
+
+```
+EM.run do
+  # Subscribe to multiple PushTopics.
+  client.subscription(['/topic/AllAccounts', '/topic/AllUsers'], with_channel: true) do |channel, message|
+    puts "Message came in on channel #{channel}"
+    puts message.inspect
+  end
+end
+```
+
+
 #### Replaying Events
 
 Since API version 37.0, Salesforce stores events for 24 hours and they can be

--- a/lib/restforce/concerns/streaming.rb
+++ b/lib/restforce/concerns/streaming.rb
@@ -26,7 +26,13 @@ module Restforce
         one_or_more_channels.each do |channel|
           replay_handlers[channel] = options[:replay]
         end
-        faye.subscribe(one_or_more_channels, &block)
+        if options[:with_channel]
+          subs = faye.subscribe(one_or_more_channels)
+          subs.each { |sub| sub.with_channel(&block) }
+        else
+          subs = faye.subscribe(one_or_more_channels, &block)
+        end
+        subs
       end
 
       # Public: Faye client to use for subscribing to PushTopics

--- a/spec/unit/concerns/streaming_spec.rb
+++ b/spec/unit/concerns/streaming_spec.rb
@@ -8,7 +8,9 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       ['/topic/topic1', '/event/MyCustomEvent__e', '/data/ChangeEvents']
     end
     let(:subscribe_block) { lambda { 'subscribe' } }
-    let(:faye_double)     { double('Faye') }
+    let(:subscribe_block_with_channels) { lambda { 'subscribe_with_channels' } }
+    let(:faye_double) { double('Faye') }
+    let(:sub_double) { double('Subscription') }
 
     it 'subscribes to the topics with faye' do
       faye_double.
@@ -17,6 +19,19 @@ describe Restforce::Concerns::Streaming, event_machine: true do
       client.stub faye: faye_double
 
       client.subscription(channels, &subscribe_block)
+    end
+
+    it 'subscribes to the topics with faye with a with_channel option' do
+      sub_double.
+        should_receive(:with_channel).
+        with(&subscribe_block_with_channels)
+      faye_double.
+        should_receive(:subscribe).
+        with(channels).
+        and_return([sub_double])
+      client.stub faye: faye_double
+
+      client.subscription(channels, with_channel: true, &subscribe_block_with_channels)
     end
 
     context "replay_handlers" do


### PR DESCRIPTION
Currently if you want to listen to events from more than one channel, you can pass an array of channels to the client.subscription call:

```
EM.run do
  # Subscribe to multiple PushTopics.
  client.subscription ['/topic/AllAccounts', '/topic/AllUsers'] do |message|
    puts message.inspect
  end
end
```

The downside to this approach is that you will not necessarily know which channel the message came from. This PR allows you to add a `with_channel:` option to the subscription call. If true, the callback will provide the channel and message:

```
EM.run do
  # Subscribe to multiple PushTopics.
  client.subscription(['/topic/AllAccounts', '/topic/AllUsers'], with_channel: true) do |channel, message|
    puts "Message came in on channel #{channel}"
    puts message.inspect
  end
end
```