### PR TITLE
Add fast path for block-less Restforce::Collection#count

### DIFF
--- a/lib/restforce/collection.rb
+++ b/lib/restforce/collection.rb
@@ -32,6 +32,12 @@ module Restforce
       @raw_page['totalSize']
     end
     alias length size
+    
+    def count
+      return size unless block_given?
+      
+      super
+    end
 
     # Returns true if the size of the Collection is zero.
     def empty?


### PR DESCRIPTION
Calling `count` is an easy footgun currently as it needlessly loads the entire collection.