### PR TITLE
Fix compositeResponse capitalization

### DIFF
--- a/lib/restforce/concerns/composite_api.rb
+++ b/lib/restforce/concerns/composite_api.rb
@@ -24,12 +24,12 @@ module Restforce
         }
         response = api_post('composite', properties.to_json)
 
-        results = response.body['CompositeResponse']
-        has_errors = results.any? { |result| result['HttpStatusCode'].digits.last == 4 }
+        results = response.body['compositeResponse']
+        has_errors = results.any? { |result| result['httpStatusCode'].digits.last == 4 }
         if all_or_none && has_errors
-          last_error_index = results.rindex { |result| result['HttpStatusCode'] != 412 }
+          last_error_index = results.rindex { |result| result['httpStatusCode'] != 412 }
           last_error = results[last_error_index]
-          raise CompositeAPIError, last_error['Body'][0]['errorCode']
+          raise CompositeAPIError, last_error['body'][0]['errorCode']
         end
 
         results

--- a/spec/unit/concerns/composite_api_spec.rb
+++ b/spec/unit/concerns/composite_api_spec.rb
@@ -128,7 +128,7 @@ describe Restforce::Concerns::CompositeAPI do
   describe '#composite' do
     let(:method) { :composite }
     let(:all_or_none) { false }
-    let(:response) { double('Faraday::Response', body: { 'CompositeResponse' => [] }) }
+    let(:response) { double('Faraday::Response', body: { 'compositeResponse' => [] }) }
     it_behaves_like 'composite requests'
   end
 
@@ -136,7 +136,7 @@ describe Restforce::Concerns::CompositeAPI do
     let(:method) { :composite! }
     let(:all_or_none) { true }
     let(:response) do
-      double('Faraday::Response', body: { 'CompositeResponse' => [] })
+      double('Faraday::Response', body: { 'compositeResponse' => [] })
     end
     it_behaves_like 'composite requests'
   end


### PR DESCRIPTION
Changes the capitalization expected in the compositeResponse object to match the docs here:

https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/responses_composite.htm
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_composite_subrequest_result.htm

I also tested the changes locally both with and without `all_or_none: true` and the `CompositeAPIError` appears to be raised with the last error as expected.

I am unsure if this is an error in the initial implementation, or if there is some API version out there that uses this as is. The composite_api_spec tests are written with API version 38 (which is much older than when composite support was added to restforce, and might just be copy/paste from other specs?). I couldn't find documentation on this type of composite request in [the docs for version 38](https://developer.salesforce.com/docs/atlas.en-us.204.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm). 

I did find documentation on this request in the [API version 39 docs](https://developer.salesforce.com/docs/atlas.en-us.206.0.api_rest.meta/api_rest/responses_composite.htm), and the response object appears to have the same type of capitalization in the response object as it does currently (API version 53), except for `referenceId` vs `referenceID` which we don't appear to extract from the response anyways. Adding these details because I couldn't really figure out if this is a breaking change or not.

Closes #678