### PR TITLE
Handle `INVALID_SIGNUP_COUNTRY` error returned by Salesforce

### DIFF
--- a/lib/restforce/error_code.rb
+++ b/lib/restforce/error_code.rb
@@ -245,6 +245,8 @@ module Restforce
 
     class InvalidSessionId < ResponseError; end
 
+    class InvalidSignupCountry < ResponseError; end
+
     class InvalidStatus < ResponseError; end
 
     class InvalidType < ResponseError; end
@@ -531,6 +533,7 @@ module Restforce
       "INVALID_REPLICATION_DATE" => InvalidReplicationDate,
       "INVALID_SAVE_AS_ACTIVITY_FLAG" => InvalidSaveAsActivityFlag,
       "INVALID_SESSION_ID" => InvalidSessionId,
+      "INVALID_SIGNUP_COUNTRY" => InvalidSignupCountry,
       "INVALID_STATUS" => InvalidStatus,
       "INVALID_TYPE" => InvalidType,
       "INVALID_TYPE_FOR_OPERATION" => InvalidTypeForOperation,


### PR DESCRIPTION
Fixes #675.