### PR TITLE
Update gemspec to reflect that `restforce` `v3.x` doesn't work with `faraday` `v1.0.0`

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.3'
 
   gem.add_dependency 'faraday', '<= 1.0', '>= 0.9.0'
-  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 1.0']
+  gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '< 1.0']
 
   gem.add_dependency 'json', '>= 1.7.5'
 


### PR DESCRIPTION
Fixes #682.