### PR TITLE
Restrict Restforce to Faraday versions before `v1.9.x`

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.6'
 
-  gem.add_dependency 'faraday', '<= 2.0', '>= 0.9.0'
+  gem.add_dependency 'faraday', '< 1.9.0', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']
   gem.add_dependency 'hashie', '>= 1.2.0', '< 6.0'
   gem.add_dependency 'jwt', ['>= 1.5.6']


### PR DESCRIPTION
This commit limits the gem to only working with compatible Faraday versions between `0.9.0` and `1.8.x`.

The recently released `1.9.x` series isn't compatible with some magic we have in `lib/restforce/file_part.rb` to maintain compatability with pre-1.0 versions - see https://github.com/lostisland/faraday/pull/1367 for the relevant changes.