### PR TITLE
Add support for Faraday 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ test/version_tmp
 tmp
 .rspec
 .ruby-version
+.tool-versions
 *.swp

--- a/lib/restforce/file_part.rb
+++ b/lib/restforce/file_part.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-begin
-  require 'faraday/file_part'
+%w[faraday/multipart faraday/file_part faraday/upload_io].find do |faraday|
+  require faraday
 rescue LoadError
-  require 'faraday/upload_io'
+  false
 end
 
 module Restforce

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.6'
 
-  gem.add_dependency 'faraday', '< 1.9.0', '>= 0.9.0'
+  gem.add_dependency 'faraday', '< 2.0', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']
   gem.add_dependency 'hashie', '>= 1.2.0', '< 6.0'
   gem.add_dependency 'jwt', ['>= 1.5.6']


### PR DESCRIPTION
I have 1.9.3 installed locally and things seem to work fine? I'm less sure about 2.x, specifically the `faraday_middleware` [deprecation](https://github.com/lostisland/faraday_middleware#%EF%B8%8F-deprecation-warning-%EF%B8%8F):

> As highlighted in Faraday's [UPGRADING](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) guide, `faraday_middleware` is DEPRECATED, and will not be updated to support Faraday 2.0. If you rely on `faraday_middleware` in your project and would like to support Faraday 2.0:
>
>    The `json` middleware (request and response) are now both bundled with Faraday 🙌
>    The `instrumentation` middleware is bundled with Faraday
>    All other middleware, they'll be re-released as independent gems compatible with both Faraday v1 and v2

Are there any other middleware that will need to be explicitly required other than `faraday-multipart` ?