### PR TITLE
Get Collection's length via "size" property if "totalSize" does not exist

### DIFF
--- a/lib/restforce/collection.rb
+++ b/lib/restforce/collection.rb
@@ -30,6 +30,10 @@ module Restforce
     # Return the number of items in the Collection without making any additional
     # requests and going through all of the pages of results, one by one. Instead,
     # we can rely on the total count of results which Salesforce returns.
+    #
+    # Most of the Salesforce API returns this in the `totalSize` attribute. For
+    # some reason, the [List View Results](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_listviewresults.htm)
+    # endpoint (and maybe others?!) uses the `size` attribute.
     def size
       @raw_page['totalSize'] || @raw_page['size']
     end

--- a/lib/restforce/collection.rb
+++ b/lib/restforce/collection.rb
@@ -31,7 +31,7 @@ module Restforce
     # requests and going through all of the pages of results, one by one. Instead,
     # we can rely on the total count of results which Salesforce returns.
     def size
-      @raw_page['totalSize']
+      @raw_page['totalSize'] || @raw_page['size']
     end
     alias length size
 

--- a/spec/fixtures/sobject/list_view_results_success_response.json
+++ b/spec/fixtures/sobject/list_view_results_success_response.json
@@ -1,0 +1,151 @@
+{
+  "columns" : [ {
+    "ascendingLabel" : "Z-A",
+    "descendingLabel" : "A-Z",
+    "fieldNameOrPath" : "Name",
+    "hidden" : false,
+    "label" : "Account Name",
+    "selectListItem" : "Name",
+    "sortDirection" : "ascending",
+    "sortIndex" : 0,
+    "sortable" : true,
+    "type" : "string"
+  }, {
+    "ascendingLabel" : "Z-A",
+    "descendingLabel" : "A-Z",
+    "fieldNameOrPath" : "Site",
+    "hidden" : false,
+    "label" : "Account Site",
+    "selectListItem" : "Site",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : true,
+    "type" : "string"
+  }, {
+    "ascendingLabel" : "Z-A",
+    "descendingLabel" : "A-Z",
+    "fieldNameOrPath" : "BillingState",
+    "hidden" : false,
+    "label" : "Billing State/Province",
+    "selectListItem" : "BillingState",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : true,
+    "type" : "string"
+  }, {
+    "ascendingLabel" : "9-0",
+    "descendingLabel" : "0-9",
+    "fieldNameOrPath" : "Phone",
+    "hidden" : false,
+    "label" : "Phone",
+    "selectListItem" : "Phone",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : true,
+    "type" : "phone"
+  }, {
+    "ascendingLabel" : "Low to High",
+    "descendingLabel" : "High to Low",
+    "fieldNameOrPath" : "Type",
+    "hidden" : false,
+    "label" : "Type",
+    "selectListItem" : "toLabel(Type)",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : true,
+    "type" : "picklist"
+  }, {
+    "ascendingLabel" : "Z-A",
+    "descendingLabel" : "A-Z",
+    "fieldNameOrPath" : "Owner.Alias",
+    "hidden" : false,
+    "label" : "Account Owner Alias",
+    "selectListItem" : "Owner.Alias",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : true,
+    "type" : "string"
+  }, {
+    "ascendingLabel" : null,
+    "descendingLabel" : null,
+    "fieldNameOrPath" : "Id",
+    "hidden" : true,
+    "label" : "Account ID",
+    "selectListItem" : "Id",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : false,
+    "type" : "id"
+  }, {
+    "ascendingLabel" : null,
+    "descendingLabel" : null,
+    "fieldNameOrPath" : "CreatedDate",
+    "hidden" : true,
+    "label" : "Created Date",
+    "selectListItem" : "CreatedDate",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : false,
+    "type" : "datetime"
+  }, {
+    "ascendingLabel" : null,
+    "descendingLabel" : null,
+    "fieldNameOrPath" : "LastModifiedDate",
+    "hidden" : true,
+    "label" : "Last Modified Date",
+    "selectListItem" : "LastModifiedDate",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : false,
+    "type" : "datetime"
+  }, {
+    "ascendingLabel" : null,
+    "descendingLabel" : null,
+    "fieldNameOrPath" : "SystemModstamp",
+    "hidden" : true,
+    "label" : "System Modstamp",
+    "selectListItem" : "SystemModstamp",
+    "sortDirection" : null,
+    "sortIndex" : null,
+    "sortable" : false,
+    "type" : "datetime"
+  } ],
+  "developerName" : "MyAccounts",
+  "done" : true,
+  "id" : "00BD0000005WcCN",
+  "label" : "My Accounts",
+  "records" : [ {
+    "columns" : [ {
+      "fieldNameOrPath" : "Name",
+      "value" : "Burlington Textiles Corp of America"
+    }, {
+      "fieldNameOrPath" : "Site",
+      "value" : null
+    }, {
+      "fieldNameOrPath" : "BillingState",
+      "value" : "NC"
+    }, {
+      "fieldNameOrPath" : "Phone",
+      "value" : "(336) 222-7000"
+    }, {
+      "fieldNameOrPath" : "Type",
+      "value" : "Customer - Direct"
+    }, {
+      "fieldNameOrPath" : "Owner.Alias",
+      "value" : "TUser"
+    }, {
+      "fieldNameOrPath" : "Id",
+      "value" : "001D000000JliSTIAZ"
+    }, {
+      "fieldNameOrPath" : "CreatedDate",
+      "value" : "Fri Aug 01 21:15:46 GMT 2014"
+    }, {
+      "fieldNameOrPath" : "LastModifiedDate",
+      "value" : "Fri Aug 01 21:15:46 GMT 2014"
+    }, {
+      "fieldNameOrPath" : "SystemModstamp",
+      "value" : "Fri Aug 01 21:15:46 GMT 2014"
+    } ]
+  } ],
+  "size" : 1
+}

--- a/spec/unit/collection_spec.rb
+++ b/spec/unit/collection_spec.rb
@@ -63,6 +63,24 @@ describe Restforce::Collection do
     end
   end
 
+  describe '#size' do
+    subject(:size) do
+      described_class.new(JSON.parse(fixture(sobject_fixture)), client).size
+    end
+
+    context 'when the query response contains a totalSize field' do
+      let(:sobject_fixture) { 'sobject/query_success_response' }
+
+      it { should eq 1 }
+    end
+
+    context 'when the query response contains a size field' do
+      let(:sobject_fixture) { 'sobject/list_view_results_success_response' }
+
+      it { should eq 1 }
+    end
+  end
+
   describe '#empty?' do
     subject(:empty?) do
       described_class.new(JSON.parse(fixture(sobject_fixture)), client).empty?


### PR DESCRIPTION
Closes https://github.com/restforce/restforce/issues/706.

As described in the issue above, there are some Salesforce REST endpoints that lack a `"totalSize"` property and instead use `"size"`. One such endpoint is [List View Results](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/resources_listviewresults.htm). When attempting to use `.size` or `.present?` (using ActiveSupport), you would get errors since it's trying to access a non-existent property. This provides a fallback by trying to use the `"size"` property if present.

I used the example output from the docs linked above as a test fixture, truncated and edited to only contain one result.