### PR TITLE
Follow redirects on authentication

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -91,29 +91,31 @@ module Restforce
       end
     end
 
-    option :api_version, default: lambda { ENV['SALESFORCE_API_VERSION'] || '26.0' }
+    option :api_version, default: lambda { ENV.fetch('SALESFORCE_API_VERSION', '26.0') }
 
     # The username to use during login.
-    option :username, default: lambda { ENV['SALESFORCE_USERNAME'] }
+    option :username, default: lambda { ENV.fetch('SALESFORCE_USERNAME', nil) }
 
     # The password to use during login.
-    option :password, default: lambda { ENV['SALESFORCE_PASSWORD'] }
+    option :password, default: lambda { ENV.fetch('SALESFORCE_PASSWORD', nil) }
 
     # The security token to use during login.
-    option :security_token, default: lambda { ENV['SALESFORCE_SECURITY_TOKEN'] }
+    option :security_token, default: lambda {
+                                       ENV.fetch('SALESFORCE_SECURITY_TOKEN', nil)
+                                     }
 
     # The OAuth client id
-    option :client_id, default: lambda { ENV['SALESFORCE_CLIENT_ID'] }
+    option :client_id, default: lambda { ENV.fetch('SALESFORCE_CLIENT_ID', nil) }
 
     # The OAuth client secret
-    option :client_secret, default: lambda { ENV['SALESFORCE_CLIENT_SECRET'] }
+    option :client_secret, default: lambda { ENV.fetch('SALESFORCE_CLIENT_SECRET', nil) }
 
     # The private key for JWT authentication
     option :jwt_key
 
     # Set this to true if you're authenticating with a Sandbox instance.
     # Defaults to false.
-    option :host, default: lambda { ENV['SALESFORCE_HOST'] || 'login.salesforce.com' }
+    option :host, default: lambda { ENV.fetch('SALESFORCE_HOST', 'login.salesforce.com') }
 
     option :oauth_token
     option :refresh_token
@@ -139,7 +141,7 @@ module Restforce
     # Faraday adapter to use. Defaults to Faraday.default_adapter.
     option :adapter, default: lambda { Faraday.default_adapter }
 
-    option :proxy_uri, default: lambda { ENV['SALESFORCE_PROXY_URI'] }
+    option :proxy_uri, default: lambda { ENV.fetch('SALESFORCE_PROXY_URI', nil) }
 
     # A Proc that is called with the response body after a successful authentication.
     option :authentication_callback

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -49,6 +49,7 @@ module Restforce
       @connection ||= Faraday.new(faraday_options) do |builder|
         builder.use Faraday::Request::UrlEncoded
         builder.use Restforce::Middleware::Mashify, nil, @options
+        builder.use FaradayMiddleware::FollowRedirects
         builder.response :json
 
         if Restforce.log?

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -44,7 +44,7 @@ describe Restforce do
           'SALESFORCE_PROXY_URI'      => 'proxy',
           'SALESFORCE_HOST'           => 'test.host.com',
           'SALESFORCE_API_VERSION'    => '37.0' }.
-          each { |var, value| ENV.stub(:[]).with(var).and_return(value) }
+          each { |var, value| ENV.stub(:fetch).with(var, anything).and_return(value) }
       end
 
       its(:username)       { should eq 'foo' }


### PR DESCRIPTION
This pull request adds the Faraday middleware to follow redirects when calling `authenticate!` because Salesforce will redirect to a classic domain (`.my.salesforce.com) when trying to use a lightning one (`.lightning.force.com`).

This is only needed when the client calls `authenticate!` directly to get a fresh token. Every other interaction happens through the `Connection` concern and the middleware is already there.