### PR TITLE
Follow redirects on authentication

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -49,6 +49,7 @@ module Restforce
       @connection ||= Faraday.new(faraday_options) do |builder|
         builder.use Faraday::Request::UrlEncoded
         builder.use Restforce::Middleware::Mashify, nil, @options
+        builder.use FaradayMiddleware::FollowRedirects
         builder.response :json
 
         if Restforce.log?


### PR DESCRIPTION
This is a duplicate of @nhocki's excellent work in #712 - but rebased on `main` so all of the tests run in GitHub Actions, and with [4f7de99](https://github.com/restforce/restforce/pull/712/commits/4f7de991c9e15d95eb8d4a65939905397589f736) removed, since those Rubocop fixes were already merged elsewhere.