### PR TITLE
Make Faraday v1.10.0 the latest supported version

### DIFF
--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        faraday_version: ['1.8.0', '1.9.0']
+        faraday_version: ['1.8.0', '1.9.0', '1.10.0']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:

--- a/lib/restforce/file_part.rb
+++ b/lib/restforce/file_part.rb
@@ -3,15 +3,15 @@
 case Faraday::VERSION
 when /\A0\./
   require 'faraday/upload_io'
-when /\A1\.9/
-  # Faraday v1.9 automatically includes the `faraday-multipart`
-  # gem, which includes `Faraday::FilePart`
-  require 'faraday/multipart'
-when /\A1\./
+when /\A1\.[0-8]\./
   # Faraday 1.x versions before 1.9 - not matched by
   # the previous clause - use `FilePart` (which must be explicitly
   # required)
   require 'faraday/file_part'
+when /\A1\./
+  # Later 1.x versions from 1.9 onwards automatically include the
+  # `faraday-multipart` gem, which includes `Faraday::FilePart`
+  require 'faraday/multipart'
 else
   raise "Unexpected Faraday version #{Faraday::VERSION} - not sure how to set up " \
         "multipart support"

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.6'
 
-  gem.add_dependency 'faraday', '< 2.0', '>= 0.9.0'
+  gem.add_dependency 'faraday', '<= 1.10.0', '>= 0.9.0'
   gem.add_dependency 'faraday_middleware', ['>= 0.8.8', '<= 2.0']
   gem.add_dependency 'hashie', '>= 1.2.0', '< 6.0'
   gem.add_dependency 'jwt', ['>= 1.5.6']


### PR DESCRIPTION
This PR:

* fixes the gem on Faraday v1.10.x, loading the correct code for multipart support
* adds tests to our CI process to make sure that Faraday v1.10.x works
* tightens up the gemspec so versions of Faraday after v1.10.0 _will not_ be allowed

## Why do we have to be so specific about Faraday versions in the gemspec?

Our dependency declaration looks like this:

```ruby
gem.add_dependency 'faraday', '<= 1.10.0', '>= 0.9.0'
```

Unsurprisingly, this means that the gem will allow versions of `faraday` between v0.9.0 and v1.10.0 inclusive, i.e.:

* v0.8.0 is _not_ allowed
* v0.9.0 is allowed
* v1.1.1 is allowed
* v1.10.0 is allowed
* v1.9.0 is allowed
* v1.10.1 is _not_ allowed

If Faraday consistently used semantic versioning, then v1.10.1 or v1.11.0 (neither of which exist!) should be safe, but there has been a history of breaking changes between versions (e.g. changes between v1.8.x and v1.9.x which we had to adapt to in #701).

I do trust that a patch version (e.g. v1.10.1) would be safe, but to my knowledge, there is no way to allow the patch versions of v1.10 without also allowing v1.11, which pushes me towards a very conservative rule.