### PR TITLE
Document on `find` raising error

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ client.find('Account', '1234', 'Some_External_Id_Field__c')
 # => #<Restforce::SObject Id="001D000000INjVe" Name="Test" LastModifiedBy="005G0000002f8FHIAY" ... >
 ```
 
+`find` raises an error if nothing is found.
+
 ### select
 
 `select` allows the fetching of a specific list of fields from a single object.  It requires an `external_id` lookup, but is often much faster than an arbitrary query.

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -429,6 +429,7 @@ module Restforce
       # field   - External ID field to use (default: nil).
       #
       # Returns the Restforce::SObject sobject record.
+      # Raises NotFoundError if nothing is found.
       def find(sobject, id, field = nil)
         url = if field
                 "sobjects/#{sobject}/#{field}/#{ERB::Util.url_encode(id)}"


### PR DESCRIPTION
I thought it would be helpful to indicate in the documentation that when `find` does not find anything, it would  raise an error instead.