### PR TITLE
Fix compatability with Faraday v0.16.x and run tests against all Faraday 0.x minor versions

### DIFF
--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        faraday_version: ['1.0.1', '1.1.0', '1.2.0', '1.3.1', '1.4.1', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0']
+        # We test v0.16.2 as a modern version rather than a legacy version because it contains v1.x-style
+        # breaking changes. See https://github.com/lostisland/faraday/releases/tag/v0.17.0.
+        faraday_version: ['0.16.2', '1.0.1', '1.1.0', '1.2.0', '1.3.1', '1.4.1', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:

--- a/.github/workflows/faraday_legacy.yml
+++ b/.github/workflows/faraday_legacy.yml
@@ -1,4 +1,4 @@
-name: 'Test against supported Faraday minor versions from v1.0 onwards'
+name: 'Test against supported Faraday minor versions before v1.0'
 on:
   push:
     branches: [main]
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        faraday_version: ['1.0.1', '1.1.0', '1.2.0', '1.3.1', '1.4.1', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0']
+        faraday_version: ['0.9.2', '0.10.1', '0.11.0', '0.12.2', '0.13.1', '0.14.0', '0.15.4', '0.16.2', '0.17.5']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:
@@ -19,7 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1
+          ruby-version: 2.6
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.github/workflows/faraday_legacy.yml
+++ b/.github/workflows/faraday_legacy.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        faraday_version: ['0.9.2', '0.10.1', '0.11.0', '0.12.2', '0.13.1', '0.14.0', '0.15.4', '0.16.2', '0.17.5']
+        # Faraday v0.16.x is not included here as that release was rolled back due to accidental
+        # breaking changes - see https://github.com/lostisland/faraday/releases/tag/v0.17.0
+        faraday_version: ['0.9.2', '0.10.1', '0.11.0', '0.12.2', '0.13.1', '0.14.0', '0.15.4', '0.17.5']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:

--- a/lib/restforce/file_part.rb
+++ b/lib/restforce/file_part.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+# rubocop:disable Lint/DuplicateBranch
 case Faraday::VERSION
+when /\A0\.16\./
+  # Faraday 0.16.x behaves like v1.x - see
+  # https://github.com/lostisland/faraday/releases/tag/v0.17.0
+  require 'faraday/file_part'
 when /\A0\./
   require 'faraday/upload_io'
 when /\A1\.[0-8]\./
@@ -16,6 +21,7 @@ else
   raise "Unexpected Faraday version #{Faraday::VERSION} - not sure how to set up " \
         "multipart support"
 end
+# rubocop:enable Lint/DuplicateBranch
 
 module Restforce
   if defined?(::Faraday::FilePart)

--- a/spec/support/faraday_version_helpers.rb
+++ b/spec/support/faraday_version_helpers.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# In our tests, we test some Faraday internals to make sure that the package
+# is working as expected. Some of those internals differ between v0.x and v1.x
+# onwards. To make things confusing, v0.16.x introduced some 1.x-style breaking
+# changes, so we treat that version like v1.x 🤷‍♂️ See
+# https://github.com/lostisland/faraday/releases/tag/v0.17.0.
+def faraday_before_first_major_version?
+  Faraday::VERSION =~ /\A0\./ && !Faraday::VERSION.start_with?("0.16")
+end

--- a/spec/unit/concerns/connection_spec.rb
+++ b/spec/unit/concerns/connection_spec.rb
@@ -73,9 +73,22 @@ describe Restforce::Concerns::Connection do
         Restforce.stub(log?: true)
       end
 
-      it "must always be used as the last handler" do
-        client.middleware.handlers.reverse.index(Restforce::Middleware::Logger).
-          should eq 0
+      context "for Faraday 1.x onwards" do
+        unless faraday_before_first_major_version?
+          it "must always be used as the last handler before the adapter" do
+            client.middleware.handlers.reverse.index(Restforce::Middleware::Logger).
+              should eq 0
+          end
+        end
+      end
+
+      context "for Faraday 0.x" do
+        if faraday_before_first_major_version?
+          it "must always be used as the last handler" do
+            client.middleware.handlers.reverse.index(Restforce::Middleware::Logger).
+              should eq 1
+          end
+        end
       end
     end
   end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -53,39 +53,82 @@ describe Restforce::Middleware::Authentication do
     describe '.builder' do
       subject(:builder) { connection.builder }
 
-      context 'with logging disabled' do
-        before do
-          Restforce.stub log?: false
-        end
+      context "for Faraday 0.x" do
+        if faraday_before_first_major_version?
+          context 'with logging disabled' do
+            before do
+              Restforce.stub log?: false
+            end
 
-        its(:handlers) {
-          should include FaradayMiddleware::ParseJson
-        }
-        its(:handlers) { should_not include Restforce::Middleware::Logger }
-        its(:adapter) { should eq Faraday::Adapter::NetHttp }
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson
+            }
+            its(:handlers) { should_not include Restforce::Middleware::Logger }
+            its(:handlers) { should include Faraday::Adapter::NetHttp }
+          end
+
+          context 'with logging enabled' do
+            before do
+              Restforce.stub log?: true
+            end
+
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson,
+                             Restforce::Middleware::Logger
+            }
+            its(:handlers) { should include Faraday::Adapter::NetHttp }
+          end
+
+          context 'with specified adapter' do
+            before do
+              options[:adapter] = :typhoeus
+            end
+
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson
+            }
+            its(:handlers) { should include Faraday::Adapter::Typhoeus }
+          end
+        end
       end
 
-      context 'with logging enabled' do
-        before do
-          Restforce.stub log?: true
+      context "for Faraday 1.x onwards" do
+        unless faraday_before_first_major_version?
+          context 'with logging disabled' do
+            before do
+              Restforce.stub log?: false
+            end
+
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson
+            }
+            its(:handlers) { should_not include Restforce::Middleware::Logger }
+            its(:adapter) { should eq Faraday::Adapter::NetHttp }
+          end
+
+          context 'with logging enabled' do
+            before do
+              Restforce.stub log?: true
+            end
+
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson,
+                             Restforce::Middleware::Logger
+            }
+            its(:adapter) { should eq Faraday::Adapter::NetHttp }
+          end
+
+          context 'with specified adapter' do
+            before do
+              options[:adapter] = :typhoeus
+            end
+
+            its(:handlers) {
+              should include FaradayMiddleware::ParseJson
+            }
+            its(:adapter) { should eq Faraday::Adapter::Typhoeus }
+          end
         end
-
-        its(:handlers) {
-          should include FaradayMiddleware::ParseJson,
-                         Restforce::Middleware::Logger
-        }
-        its(:adapter) { should eq Faraday::Adapter::NetHttp }
-      end
-
-      context 'with specified adapter' do
-        before do
-          options[:adapter] = :typhoeus
-        end
-
-        its(:handlers) {
-          should include FaradayMiddleware::ParseJson
-        }
-        its(:adapter) { should eq Faraday::Adapter::Typhoeus }
       end
     end
 
@@ -97,23 +140,54 @@ describe Restforce::Middleware::Authentication do
   end
 
   describe '.error_message' do
-    context 'when response.body is present' do
-      let(:response) {
-        Faraday::Response.new(
-          response_body: { 'error' => 'error', 'error_description' => 'description' },
-          status: 401
-        )
-      }
+    context "for Faraday 1.x onwards" do
+      unless faraday_before_first_major_version?
+        context 'when response_body is present' do
+          let(:response) {
+            Faraday::Response.new(
+              response_body: { 'error' => 'error', 'error_description' => 'description' },
+              status: 401
+            )
+          }
 
-      subject { middleware.error_message(response) }
-      it { should eq "error: description (401)" }
+          subject { middleware.error_message(response) }
+          it { should eq "error: description (401)" }
+        end
+
+        context 'when response_body is nil' do
+          let(:response) { Faraday::Response.new(status: 401) }
+
+          subject { middleware.error_message(response) }
+          it { should eq "401" }
+        end
+      end
     end
 
-    context 'when response.body is nil' do
-      let(:response) { Faraday::Response.new(status: 401) }
+    context "for Faraday 0.x" do
+      if faraday_before_first_major_version?
+        context 'when response.body is present' do
+          let(:response) {
+            Faraday::Response.new(
+              response: {
+                body: { 'error' => 'error', 'error_description' => 'description' }
+              },
+              status: 401
+            )
+          }
 
-      subject { middleware.error_message(response) }
-      it { should eq "401" }
+          subject { middleware.error_message(response) }
+
+          # TODO: Investigate this behaviour in Faraday 0.x, which looks wrong
+          it { should eq "401" }
+        end
+
+        context 'when response.body is nil' do
+          let(:response) { Faraday::Response.new(status: 401) }
+
+          subject { middleware.error_message(response) }
+          it { should eq "401" }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR started with a simple observation: the gemspec says that the gem support Faraday 0.9.0 onwards, but we weren't actually testing against anything against below v1.x in CI.

It ends up making two distinct changes:

* **Test against Faraday v0.x minor versions from v0.9.0 onwards in CI - and get those tests passing**: I enabled testing, and found that a bunch of tests were broken - mostly due to differences in Faraday internals between versions, which our tests can see because we dig quite deep into Faraday to check that the gem actually works as expected.For those cases, I have introduced separate tests for Faraday 0.x and Faraday 1.x onwards. An alternative option would be to remove these Faraday internals tests, but I'd like to be more thoughtful and strategic on that.
* **Fix support for Faraday v0.16.x, which behaves like v1.x in lots of ways**: Faraday v0.16 was released with a bunch of breaking changes, and then "cancelled" in favour of putting those changes in v1.0, but v0.16.x is still out there and people could be using it. This fixes compatibility with it by enabling multipart support in the way that we do for v1.x.