### PR TITLE
Drop support for Ruby 2.6, which has reached end of life (EOL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.6', '2.7', '3.0', '3.1', '3.2.0-preview1']
+        ruby_version: ['2.7', '3.0', '3.1', '3.2.0-preview1']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - .*/**/*
     - vendor/**/*
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 # Limit lines to 90 characters.
 Layout/LineLength:

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -71,16 +71,16 @@ module Restforce
     # Alias for Restforce::Data::Client.new
     #
     # Shamelessly pulled from https://github.com/pengwynn/octokit/blob/master/lib/octokit.rb
-    def new(*args, &block)
-      data(*args, &block)
+    def new(...)
+      data(...)
     end
 
-    def data(*args, &block)
-      Restforce::Data::Client.new(*args, &block)
+    def data(...)
+      Restforce::Data::Client.new(...)
     end
 
-    def tooling(*args, &block)
-      Restforce::Tooling::Client.new(*args, &block)
+    def tooling(...)
+      Restforce::Tooling::Client.new(...)
     end
 
     # Helper for decoding signed requests.

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 'rubygems_mfa_required' => 'true'
   }
 
-  gem.required_ruby_version = '>= 2.6'
+  gem.required_ruby_version = '>= 2.7'
 
   gem.add_dependency 'faraday', '< 2.5.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '<= 0.3.0', '< 1.0.0'


### PR DESCRIPTION
This drops support for Ruby 2.6, which has reached end of life (EOL)

I plan to release this change as a new major version, v6.0.0, starting with a release candidate version to gather feedback, so I am merging into a `v6.0.0.rc.1` branch. In the major version, this will be combined with dropping support for Faraday versions before v1.1.0 (and adding support for Faraday v2.x!) - see #721.