### PR TITLE
Add a note about JWT token caching to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ export SALESFORCE_API_VERSION="41.0"
 client = Restforce.new
 ```
 
+**Note:** Restforce library does not cache JWT Bearer tokens automatically. This means that every instantiation of the Restforce class will be treated as a new login by Salesforce. Remember that Salesforce enforces [rate limits on login requests](https://help.salesforce.com/s/articleView?id=000312767&type=1). If you are building an application that will instantiate the Restforce class more than this specified rate limit, you might want to consider caching the Bearer token either in-memory or in your own storage by leveraging the `authentication_callback` method. 
+
 #### Sandbox Organizations
 
 You can connect to sandbox organizations by specifying a host. The default host is


### PR DESCRIPTION
This pull request adds a note about the risk of using JWT auth mechanism without any caching. 

We are using restforce in our of our internal applications and we ran into the `LOGIN_RATE_EXCEEDED` error from Salesforce ([reference](https://help.salesforce.com/s/articleView?id=000312767&type=1)) once we exceed 3600 logins per hour. We implemented an internal caching mechanism that reuses bearer tokens to overcome this error. Hopefully the note we are adding will prevent other developers from running into the same issue as us. 