### PR TITLE
Add support for bulk upsert via Bulk API 2.0

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -33,6 +33,7 @@ module Restforce
     autoload :API,            'restforce/concerns/api'
     autoload :BatchAPI,       'restforce/concerns/batch_api'
     autoload :CompositeAPI,   'restforce/concerns/composite_api'
+    autoload :BulkAPI,        'restforce/concerns/bulk_api'
   end
 
   module Data
@@ -50,6 +51,7 @@ module Restforce
   APIVersionError     = Class.new(Error)
   BatchAPIError       = Class.new(Error)
   CompositeAPIError   = Class.new(Error)
+  BulkAPIError        = Class.new(Error)
 
   # Inherit from Faraday::ResourceNotFound for backwards-compatibility
   # Consumers of this library that rescue and handle Faraday::ResourceNotFound

--- a/lib/restforce/abstract_client.rb
+++ b/lib/restforce/abstract_client.rb
@@ -9,5 +9,6 @@ module Restforce
     include Restforce::Concerns::API
     include Restforce::Concerns::BatchAPI
     include Restforce::Concerns::CompositeAPI
+    include Restforce::Concerns::BulkAPI
   end
 end

--- a/lib/restforce/concerns/bulk_api.rb
+++ b/lib/restforce/concerns/bulk_api.rb
@@ -1,30 +1,46 @@
 # frozen_string_literal: true
 
 require 'restforce/concerns/verbs'
+require 'csv'
 
 module Restforce
   module Concerns
     module BulkAPI
+      module JobState
+        OPEN = 'Open'
+        UPLOAD_COMPLETED = 'UploadComplete'
+        ABORTED = 'Aborted'
+        JOB_COMPLETED = 'JobComplete'
+        FAILED = 'Failed'
+      end
+
       extend Restforce::Concerns::Verbs
 
-      define_verbs :post
+      define_verbs :post, :put, :patch
 
-      def bulk_upsert(sobject_name, external_key, _data)
-        create_job_response = api_post(
-          UpsertJob.api_path,
+      def bulk_upsert(sobject_name, external_key, data)
+        response_on_create = api_post(
+          'jobs/ingest',
           UpsertJob.create_params(sobject_name, external_key).to_json
         )
 
-        job = UpsertJob.new(create_job_response.body)
+        job = UpsertJob.new(response_on_create.body)
+
+        api_put(
+          "#{job.api_path}/batches",
+          job.prepare_upload_content(data)
+        )
+
+        api_patch(
+          job.api_path,
+          job.patch_state_params(JobState::UPLOAD_COMPLETED).to_json
+        )
+
         job
       end
 
       class UpsertJob
         attr_reader :id, :object_name, :external_key
-
-        def self.api_path
-          'jobs/ingest'
-        end
 
         def self.create_params(sobject_name, external_key)
           {
@@ -36,8 +52,23 @@ module Restforce
           }
         end
 
-        def initialize(create_job_response_body)
-          @id = create_job_response_body['id']
+        def initialize(response_body)
+          @id = response_body['id']
+          @object_name = response_body['object']
+          @external_key = response_body['externalIdField']
+        end
+
+        def api_path
+          "jobs/#{id}"
+        end
+
+        def patch_state_params(state)
+          { 'state' => state }
+        end
+
+        def prepare_upload_content(_data)
+          # TODO: turn it into a CSV
+          []
         end
       end
     end

--- a/lib/restforce/concerns/bulk_api.rb
+++ b/lib/restforce/concerns/bulk_api.rb
@@ -59,13 +59,14 @@ module Restforce
         def self.retrieve(job_id, connection:, options:)
           response = connection.
                      get("/services/data/v#{options[:api_version]}/jobs/ingest/#{job_id}")
-
           body = response.body
 
           job = new(body['object'], body['externalIdFieldName'], connection: connection,
                                                                  options: options)
           job.send(:id=, job_id)
           job
+        rescue Restforce::NotFoundError
+          raise BulkAPIError, "job with id #{job_id} cannot be found."
         end
 
         def bulk_api_path(path = '')

--- a/lib/restforce/concerns/bulk_api.rb
+++ b/lib/restforce/concerns/bulk_api.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'restforce/concerns/verbs'
+
+module Restforce
+  module Concerns
+    module BulkAPI
+      extend Restforce::Concerns::Verbs
+
+      define_verbs :post
+
+      class Job
+        attr_reader :id, :object_name, :external_key
+
+        def initialize(object_name:, external_key:)
+          @object_name = object_name
+          @external_key = external_key
+        end
+      end
+    end
+  end
+end

--- a/lib/restforce/concerns/bulk_api.rb
+++ b/lib/restforce/concerns/bulk_api.rb
@@ -9,12 +9,35 @@ module Restforce
 
       define_verbs :post
 
-      class Job
+      def bulk_upsert(sobject_name, external_key, _data)
+        create_job_response = api_post(
+          UpsertJob.api_path,
+          UpsertJob.create_params(sobject_name, external_key).to_json
+        )
+
+        job = UpsertJob.new(create_job_response.body)
+        job
+      end
+
+      class UpsertJob
         attr_reader :id, :object_name, :external_key
 
-        def initialize(object_name:, external_key:)
-          @object_name = object_name
-          @external_key = external_key
+        def self.api_path
+          'jobs/ingest'
+        end
+
+        def self.create_params(sobject_name, external_key)
+          {
+            object: sobject_name,
+            contentType: 'CSV',
+            operation: 'upsert',
+            lineEnding: 'LF',
+            externalIdFieldName: external_key
+          }
+        end
+
+        def initialize(create_job_response_body)
+          @id = create_job_response_body['id']
         end
       end
     end

--- a/spec/unit/concerns/bulk_api_spec.rb
+++ b/spec/unit/concerns/bulk_api_spec.rb
@@ -64,5 +64,22 @@ describe Restforce::Concerns::BulkAPI do
         expect(retrieved_job.external_key).to eq 'bar'
       end
     end
+
+    context 'with an invalid job id' do
+      let(:response) { Faraday::Response.new(status: 404) }
+
+      before do
+        expect(connection).
+          to receive(:get).
+          with("/services/data/v#{api_version}/jobs/ingest/invalid_id").
+          and_raise(Restforce::NotFoundError.new(nil))
+      end
+
+      it 'raises BulkApiError' do
+        expect do
+          client.retrieve_ingest_job('invalid_id')
+        end.to raise_error Restforce::BulkAPIError
+      end
+    end
   end
 end

--- a/spec/unit/concerns/bulk_api_spec.rb
+++ b/spec/unit/concerns/bulk_api_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restforce::Concerns::BulkAPI do
+  let(:endpoint) { 'jobs/ingest' }
+
+  describe '.bulk_upsert' do
+    let(:response) do
+      double('Faraday::Response', body: {
+               'id' => 'abc',
+               'operation' => 'upsert',
+               'object' => 'foo',
+               'externalIdFieldName' => 'bar'
+             })
+    end
+
+    before do
+      create_job_payload = {
+        object: 'foo',
+        contentType: 'CSV',
+        operation: 'upsert',
+        lineEnding: 'LF',
+        externalIdFieldName: 'bar'
+      }
+
+      allow(client).
+        to receive(:api_post).
+        with(endpoint, create_job_payload.to_json).
+        and_return(response)
+    end
+
+    it 'returns the UpsertJob' do
+      job = client.bulk_upsert("foo", "bar", [])
+      expect(job.id).to eq 'abc'
+    end
+  end
+end

--- a/spec/unit/concerns/bulk_api_spec.rb
+++ b/spec/unit/concerns/bulk_api_spec.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'csv'
 
 describe Restforce::Concerns::BulkAPI do
   let(:endpoint) { 'jobs/ingest' }
 
   describe '.bulk_upsert' do
-    let(:response) do
+    let(:response_on_create) do
       double('Faraday::Response', body: {
                'id' => 'abc',
                'operation' => 'upsert',
@@ -14,6 +15,9 @@ describe Restforce::Concerns::BulkAPI do
                'externalIdFieldName' => 'bar'
              })
     end
+
+    let(:response_on_put) { double('Faraday::Response', body: {}) }
+    let(:response_on_patch) { double('Faraday::Response', body: {}) }
 
     before do
       create_job_payload = {
@@ -27,7 +31,17 @@ describe Restforce::Concerns::BulkAPI do
       allow(client).
         to receive(:api_post).
         with(endpoint, create_job_payload.to_json).
-        and_return(response)
+        and_return(response_on_create)
+
+      allow(client).
+        to receive(:api_put).
+        with('jobs/abc/batches', []).
+        and_return(response_on_put)
+
+      allow(client).
+        to receive(:api_patch).
+        with('jobs/abc', { 'state' => 'UploadComplete' }.to_json).
+        and_return(response_on_put)
     end
 
     it 'returns the UpsertJob' do


### PR DESCRIPTION
## What?

Add support for bulk upsert via Bulk API 2.0 based on the official [documentation](https://developer.salesforce.com/docs/atlas.en-us.232.0.api_asynch.meta/api_asynch/walkthrough_upsert.htm).

Useful when a large set of records need to be upserted in one-go.

**Checklist:**
- [x] ability to create a job
- [x] ability to fetch for a job
- [ ]  finalize how to pass the data to the `#bulk_upsert` method
- [ ] ability to fetch for in-progress/succeeded/failed records
- [ ] ability to abort/delete a job

## Client API

### Upsert
```rb
client.bulk_upsert('some_sobject', 'ext_name', [...]) # returns a `BulkUpsert` job instance
```

### Retrieves a job
```rb
client.retrieve_ingest_job('some_job_id') # returns a `BulkUpsert` job instance
```
