### PR TITLE
Add new `clear_authorization_header` option to decide whether to continue sending authentication headers when redirected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ tmp
 .rspec
 .ruby-version
 *.swp
+.idea
+Vagrantfile
+.vagrant/

--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -58,10 +58,10 @@ module Restforce
       #        :request_headers         - A hash containing custom headers that will be
       #                                   appended to each request
       #
-      #     :clear_authorization_header - A boolean that when set to false will cause
+      #     :clear_authorization_header - A boolean that when set to true will cause
       #                                   the Faraday::FollowRedirects middleware to
-      #                                   include the auth header when following
-      #                                   redirects (default: true)
+      #                                   omit the auth header when following
+      #                                   redirects (default: false)
 
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)

--- a/lib/restforce/concerns/base.rb
+++ b/lib/restforce/concerns/base.rb
@@ -57,6 +57,11 @@ module Restforce
       #
       #        :request_headers         - A hash containing custom headers that will be
       #                                   appended to each request
+      #
+      #     :clear_authorization_header - A boolean that when set to false will cause
+      #                                   the Faraday::FollowRedirects middleware to
+      #                                   include the auth header when following
+      #                                   redirects (default: true)
 
       def initialize(opts = {})
         raise ArgumentError, 'Please specify a hash of options' unless opts.is_a?(Hash)

--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -43,7 +43,10 @@ module Restforce
           # Caches GET requests.
           builder.use Restforce::Middleware::Caching, cache, options if cache
           # Follows 30x redirects.
-          builder.use Faraday::FollowRedirects::Middleware options
+          builder.use Faraday::FollowRedirects::Middleware, {
+            # Pass the option to clear or send the auth header on redirects through
+            clear_authorization_header: options[:clear_authorization_header]
+          }
           # Raises errors for 40x responses.
           builder.use Restforce::Middleware::RaiseError
           # Parses returned JSON response into a hash.

--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -43,7 +43,7 @@ module Restforce
           # Caches GET requests.
           builder.use Restforce::Middleware::Caching, cache, options if cache
           # Follows 30x redirects.
-          builder.use Faraday::FollowRedirects::Middleware
+          builder.use Faraday::FollowRedirects::Middleware options
           # Raises errors for 40x responses.
           builder.use Restforce::Middleware::RaiseError
           # Parses returned JSON response into a hash.

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -161,9 +161,9 @@ module Restforce
     # Set use_cache to false to opt in to caching with client.with_caching
     option :use_cache, default: true
 
-    # Set to false to have Faraday::FollowRedirects middleware include auth header
+    # Set to true to have Faraday::FollowRedirects middleware omit the auth header
     # when following redirects
-    option :clear_authorization_header, default: true
+    option :clear_authorization_header, default: false
 
     def options
       self.class.options

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -161,7 +161,8 @@ module Restforce
     # Set use_cache to false to opt in to caching with client.with_caching
     option :use_cache, default: true
 
-    # Set to false to have Faraday::FollowRedirects middleware include the auth header on requests as it follows redirects
+    # Set to false to have Faraday::FollowRedirects middleware include auth header
+    # when following redirects
     option :clear_authorization_header, default: true
 
     def options

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -161,6 +161,9 @@ module Restforce
     # Set use_cache to false to opt in to caching with client.with_caching
     option :use_cache, default: true
 
+    # Set to false to have Faraday::FollowRedirects middleware include the auth header on requests as it follows redirects
+    option :clear_authorization_header, default: true
+
     def options
       self.class.options
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -62,7 +62,7 @@ describe Restforce do
     %i[username password security_token client_id client_secret compress
        timeout oauth_token refresh_token instance_url api_version host mashify
        authentication_retries proxy_uri authentication_callback ssl
-       request_headers log_level logger].each do |attr|
+       request_headers log_level logger clear_authorization_header].each do |attr|
       it "allows #{attr} to be set" do
         Restforce.configure do |config|
           config.send("#{attr}=", 'foobar')


### PR DESCRIPTION
Passes a new option (clear_authorization_header) through to the FollowRedirects middleware so that the authorization header can be included in requests as we follow redirects across Salesforce domains.