### PR TITLE
Add support for Faraday v2.5.x and v2.6.x

### DIFF
--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -10,7 +10,7 @@ jobs:
         # For v2.0.x, we test v2.0.0 and v2.0.1 because v2.0.0 has a special behaviour where
         # the Net::HTTP adapter is not included. See
         # https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20.
-        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.1', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0']
+        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.1', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.0', '2.6.0']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.7'
 
-  gem.add_dependency 'faraday', '< 2.5.0', '>= 1.1.0'
+  gem.add_dependency 'faraday', '< 2.7.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '<= 0.3.0', '< 1.0.0'
   gem.add_dependency 'faraday-multipart', '>= 1.0.0', '< 2.0.0'
   gem.add_dependency 'faraday-net_http', '< 4.0.0'


### PR DESCRIPTION
This updates the gemspec to allow Faraday versions up to `2.7.0` - effectively adding official support for v2.5.x and v2.6.x. At the same time, it includes these Faraday minor versions in our testing process.

We take this approach to Faraday compatibility because Faraday has an unfortunate history of reasonably frequently releasing minor versions (`major.minor.patch`) with breaking changes, and we want to check that each version actually works.

Inspired by #758.