### PR TITLE
include response body for CompositeAPIError

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -50,15 +50,6 @@ module Restforce
   APIVersionError     = Class.new(Error)
   BatchAPIError       = Class.new(Error)
 
-  class CompositeAPIError < Error
-    attr_reader :composite_response
-
-    def initialize(msg, composite_response = nil)
-      @composite_response = composite_response
-      super(msg)
-    end
-  end
-
   # Inherit from Faraday::ResourceNotFound for backwards-compatibility
   # Consumers of this library that rescue and handle Faraday::ResourceNotFound
   # can continue to do so.
@@ -68,6 +59,7 @@ module Restforce
   # Consumers of this library that rescue and handle Faraday::ClientError
   # can continue to do so.
   ResponseError       = Class.new(Faraday::ClientError)
+  CompositeAPIError   = Class.new(ResponseError)
   MatchesMultipleError= Class.new(ResponseError)
   EntityTooLargeError = Class.new(ResponseError)
 

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -49,7 +49,15 @@ module Restforce
   UnauthorizedError   = Class.new(Faraday::ClientError)
   APIVersionError     = Class.new(Error)
   BatchAPIError       = Class.new(Error)
-  CompositeAPIError   = Class.new(Error)
+
+  class CompositeAPIError < Error
+    attr_reader :composite_response
+
+    def initialize(msg, composite_response = nil)
+      @composite_response = composite_response
+      super(msg)
+    end
+  end
 
   # Inherit from Faraday::ResourceNotFound for backwards-compatibility
   # Consumers of this library that rescue and handle Faraday::ResourceNotFound

--- a/lib/restforce/concerns/composite_api.rb
+++ b/lib/restforce/concerns/composite_api.rb
@@ -29,7 +29,7 @@ module Restforce
         if all_or_none && has_errors
           last_error_index = results.rindex { |result| result['httpStatusCode'] != 412 }
           last_error = results[last_error_index]
-          raise CompositeAPIError, last_error['body'][0]['errorCode']
+          raise CompositeAPIError.new(last_error['body'][0]['errorCode'], results)
         end
 
         results

--- a/lib/restforce/concerns/composite_api.rb
+++ b/lib/restforce/concerns/composite_api.rb
@@ -29,7 +29,7 @@ module Restforce
         if all_or_none && has_errors
           last_error_index = results.rindex { |result| result['httpStatusCode'] != 412 }
           last_error = results[last_error_index]
-          raise CompositeAPIError.new(last_error['body'][0]['errorCode'], results)
+          raise CompositeAPIError.new(last_error['body'][0]['errorCode'], response)
         end
 
         results

--- a/spec/unit/concerns/composite_api_spec.rb
+++ b/spec/unit/concerns/composite_api_spec.rb
@@ -139,5 +139,31 @@ describe Restforce::Concerns::CompositeAPI do
       double('Faraday::Response', body: { 'compositeResponse' => [] })
     end
     it_behaves_like 'composite requests'
+
+    it 'throws error with composite response in error' do
+      response = double('Faraday::Response',
+                        body: { 'compositeResponse' =>
+                                  [{ 'httpStatusCode' => 400,
+                                     'body' => [{ 'errorCode' =>
+                                                    'DUPLICATE_VALUE' }] }] })
+      client.
+        should_receive(:api_post).
+        with(endpoint, { compositeRequest: [
+          {
+            method: 'POST',
+            url: '/services/data/v38.0/sobjects/Object',
+            body: { name: 'test' },
+            referenceId: 'create_ref'
+          }
+        ], allOrNone: all_or_none, collateSubrequests: false }.to_json).
+        and_return(response)
+
+      expect do
+        client.send(method) do |subrequests|
+          subrequests.create('Object', 'create_ref', name: 'test')
+        end
+      end.to raise_error(an_instance_of(Restforce::CompositeAPIError).
+        and(having_attributes(composite_response: response.body['compositeResponse'])))
+    end
   end
 end

--- a/spec/unit/concerns/composite_api_spec.rb
+++ b/spec/unit/concerns/composite_api_spec.rb
@@ -123,6 +123,32 @@ describe Restforce::Concerns::CompositeAPI do
         end
       end.to raise_error(ArgumentError)
     end
+
+    it 'has response in CompositeAPIError' do
+      response = double('Faraday::Response',
+                        body: { 'compositeResponse' =>
+                                  [{ 'httpStatusCode' => 400,
+                                     'body' => [{ 'errorCode' =>
+                                                    'DUPLICATE_VALUE' }] }] })
+      client.
+        should_receive(:api_post).
+        with(endpoint, { compositeRequest: [
+          {
+            method: 'POST',
+            url: '/services/data/v38.0/sobjects/Object',
+            body: { name: 'test' },
+            referenceId: 'create_ref'
+          }
+        ], allOrNone: true, collateSubrequests: false }.to_json).
+        and_return(response)
+      arg = method == :composite ? { all_or_none: true } : {}
+      expect do
+        client.send(method, arg) do |subrequests|
+          subrequests.create('Object', 'create_ref', name: 'test')
+        end
+      end.to raise_error(an_instance_of(Restforce::CompositeAPIError).
+        and(having_attributes(response: response)))
+    end
   end
 
   describe '#composite' do
@@ -139,31 +165,5 @@ describe Restforce::Concerns::CompositeAPI do
       double('Faraday::Response', body: { 'compositeResponse' => [] })
     end
     it_behaves_like 'composite requests'
-
-    it 'throws error with composite response in error' do
-      response = double('Faraday::Response',
-                        body: { 'compositeResponse' =>
-                                  [{ 'httpStatusCode' => 400,
-                                     'body' => [{ 'errorCode' =>
-                                                    'DUPLICATE_VALUE' }] }] })
-      client.
-        should_receive(:api_post).
-        with(endpoint, { compositeRequest: [
-          {
-            method: 'POST',
-            url: '/services/data/v38.0/sobjects/Object',
-            body: { name: 'test' },
-            referenceId: 'create_ref'
-          }
-        ], allOrNone: all_or_none, collateSubrequests: false }.to_json).
-        and_return(response)
-
-      expect do
-        client.send(method) do |subrequests|
-          subrequests.create('Object', 'create_ref', name: 'test')
-        end
-      end.to raise_error(an_instance_of(Restforce::CompositeAPIError).
-        and(having_attributes(composite_response: response.body['compositeResponse'])))
-    end
   end
 end


### PR DESCRIPTION
Related to https://github.com/restforce/restforce/issues/766
### Changes
Allow `CompositeAPIError` to include Faraday's response
### Testing
I added one test related to this change &  ran rspec locally. 