### PR TITLE
Run tests against Ruby v3.2.0 in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.7', '3.0', '3.1', '3.2.0-preview1']
+        ruby_version: ['2.7', '3.0', '3.1', '3.2']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-faraday_version = ENV.fetch('FARADAY_VERSION', '~> 1.8.0')
+faraday_version = ENV.fetch('FARADAY_VERSION', '~> 2.6.0')
 
 # Enable us to explicitly pick a Faraday version when running tests
 gem 'faraday', faraday_version


### PR DESCRIPTION
This PR updates our build matrix to run tests against Ruby 3.2.0, the latest version, in CI.

To enable this change, I also update the default version of Faraday in development and testing from v1.8.0 to v2.6.0. 

This is because, due to a [bug](https://github.com/lostisland/faraday/issues/1479) in Faraday, the older v1.x version we're using doesn't work with the latest Ruby. This seems like a sensible change anyway, given that we do always test older Faraday versions.