### PR TITLE
Fix broken Composite API-related tests

### DIFF
--- a/spec/unit/concerns/composite_api_spec.rb
+++ b/spec/unit/concerns/composite_api_spec.rb
@@ -143,7 +143,7 @@ describe Restforce::Concerns::CompositeAPI do
         and_return(response)
       arg = method == :composite ? { all_or_none: true } : {}
       expect do
-        client.send(method, arg) do |subrequests|
+        client.send(method, **arg) do |subrequests|
           subrequests.create('Object', 'create_ref', name: 'test')
         end
       end.to raise_error(an_instance_of(Restforce::CompositeAPIError).


### PR DESCRIPTION
This fixes some Composite API-related tests that somehow ended up turning red after #756 was merged. The failures are related to new keyword arguments related behaviour in newer Ruby versions.