### PR TITLE
When a response claims to be gzipped but isn't, return the body as it is and don't explode

### DIFF
--- a/lib/restforce/middleware/gzip.rb
+++ b/lib/restforce/middleware/gzip.rb
@@ -28,6 +28,10 @@ module Restforce
     # Internal: Decompresses a gzipped string.
     def decompress(body)
       Zlib::GzipReader.new(StringIO.new(body)).read
+    rescue Zlib::GzipFile::Error
+      # We thought the response was gzipped, but it wasn't. Return the original
+      # body back to the caller. See https://github.com/restforce/restforce/issues/761.
+      body
     end
   end
 end


### PR DESCRIPTION
In the past couple of months (see #761), users have reported an issue where some API calls raise a `Zlib::GzipFile::Error`.

The root cause [seems][1] to be that Restforce is seeing a `Content-Encoding` response header and thinking that it needs to decompress the body, when in fact, the body is not compressed. When you try to decompress something with Gzip that isn't compressed, it raises an error.

This catches that error and returns the body as is.

It doesn't really answer the underlying question - "why do we think the response is encoded?" - but it should unblock users.

Fixes #761.

[1]: https://github.com/restforce/restforce/issues/761#issuecomment-1329012277