### PR TITLE
[#258] Initial import of CompositeTree Api

### DIFF
--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -33,6 +33,7 @@ module Restforce
     autoload :API,            'restforce/concerns/api'
     autoload :BatchAPI,       'restforce/concerns/batch_api'
     autoload :CompositeAPI,   'restforce/concerns/composite_api'
+    autoload :CompositeTreeAPI, 'restforce/concerns/composite_tree_api'
   end
 
   module Data
@@ -60,6 +61,7 @@ module Restforce
   # can continue to do so.
   ResponseError       = Class.new(Faraday::ClientError)
   CompositeAPIError   = Class.new(ResponseError)
+  CompositeTreeAPIError = Class.new(ResponseError)
   MatchesMultipleError= Class.new(ResponseError)
   EntityTooLargeError = Class.new(ResponseError)
 

--- a/lib/restforce/abstract_client.rb
+++ b/lib/restforce/abstract_client.rb
@@ -9,5 +9,6 @@ module Restforce
     include Restforce::Concerns::API
     include Restforce::Concerns::BatchAPI
     include Restforce::Concerns::CompositeAPI
+    include Restforce::Concerns::CompositeTreeAPI
   end
 end

--- a/lib/restforce/concerns/composite_tree_api.rb
+++ b/lib/restforce/concerns/composite_tree_api.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'restforce/concerns/verbs'
+
+module Restforce
+  module Concerns
+    module CompositeTreeAPI
+      extend Restforce::Concerns::Verbs
+
+      define_verbs :post
+
+      def composite_tree(root, records = [])
+        begin
+          response = api_post("composite/tree/#{root}", { records: records }.to_json)
+        rescue Restforce::ResponseError => e
+          raise CompositeTreeAPIError, Hashie::Mash.new(e.response)
+        end
+
+        response.body['results']
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
adding initial support for sObject tree creation

I'm thinking an interface like the following
```
ret = client.composite_tree('Account') do |accounts|
  accounts.add(name: "foo") do |sub|
    sub.embed("Contacts") do |contacts|
      contacts.add(FirstName: 'John', LastName: 'Smith')
    end
    sub.embed("Opportunities") do |opportunities|
      opportunities.add("Name" => "@{contact.FirstName} #{idx} opp",
                        "StageName" => 'closed/won')
    end
  end
end
```
