### PR TITLE
fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ruby:2.6.5-alpine
+FROM ruby:2.7.0-alpine
 
 RUN apk add --no-cache \
   ca-certificates \
   wget \
-  openssl \ 
+  openssl \
   bash \
   build-base \
   git \


### PR DESCRIPTION
https://github.com/restforce/restforce/blob/main/CONTRIBUTING.md#docker

An error occurred because there was unnecessary space and the ruby ​​version was low

```
$ docker-compose build --pull
[+] Building 7.3s (12/13)                                                                                                                                                                                                                                                       
 => [restforce internal] load .dockerignore                                                                                                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                            0.0s
 => [restforce internal] load build definition from Dockerfile                                                                                                                                                                                                             0.0s
 => => transferring dockerfile: 619B                                                                                                                                                                                                                                       0.0s
 => [restforce internal] load metadata for docker.io/library/ruby:2.6.5-alpine                                                                                                                                                                                             2.3s
 => [restforce auth] library/ruby:pull token for registry-1.docker.io                                                                                                                                                                                                      0.0s
 => [restforce 1/8] FROM docker.io/library/ruby:2.6.5-alpine@sha256:a5b974e2ebb2b72642f4de4e5562597ec0883c3bfd93e9553cee6bd395dfbf00                                                                                                                                       0.0s
 => [restforce internal] load build context                                                                                                                                                                                                                                0.0s
 => => transferring context: 2.12MB                                                                                                                                                                                                                                        0.0s
 => CACHED [restforce 2/8] RUN apk add --no-cache   ca-certificates   wget   openssl   bash   build-base   git   sqlite-dev   tzdata   tini                                                                                                                                0.0s
 => CACHED [restforce 3/8] RUN gem install bundler -v 2.1.4 -i /usr/local/lib/ruby/gems/$(ls /usr/local/lib/ruby/gems) --force                                                                                                                                             0.0s
 => CACHED [restforce 4/8] WORKDIR /srv                                                                                                                                                                                                                                    0.0s
 => CACHED [restforce 5/8] COPY Gemfile restforce.gemspec /srv/                                                                                                                                                                                                            0.0s
 => CACHED [restforce 6/8] COPY lib/restforce/version.rb /srv/lib/restforce/version.rb                                                                                                                                                                                     0.0s
 => ERROR [restforce 7/8] RUN bundle install                                                                                                                                                                                                                               4.9s
------                                                                                                                                                                                                                                                                          
 > [restforce 7/8] RUN bundle install:                                                                                                                                                                                                                                          
#0 0.381 fatal: not a git repository (or any of the parent directories): .git                                                                                                                                                                                                   
#0 0.417 The dependency jruby-openssl (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for java. To add those platforms to the bundle, run `bundle lock --add-platform java`.                 
#0 3.352 Fetching gem metadata from https://rubygems.org/.............                                                                                                                                                                                                          
#0 4.786 Fetching gem metadata from https://rubygems.org/.                                                                                                                                                                                                                      
#0 4.806 Resolving dependencies...
#0 4.824 Bundler found conflicting requirements for the Ruby version:
#0 4.824   In Gemfile:
#0 4.824     Ruby
#0 4.824 
#0 4.824     restforce was resolved to 6.2.3, which depends on
#0 4.824       Ruby (>= 2.7)
#0 4.824 
#0 4.824 Ruby (>= 2.7), which is required by gem 'restforce', is not available in the
#0 4.824 local ruby installation
------
failed to solve: process "/bin/sh -c bundle install" did not complete successfully: exit code: 6
```