### PR TITLE
Add support for oauth client credential

### DIFF
--- a/lib/restforce/concerns/authentication.rb
+++ b/lib/restforce/concerns/authentication.rb
@@ -15,13 +15,19 @@ module Restforce
 
       # Internal: Determines what middleware will be used based on the options provided
       def authentication_middleware
-        if username_password?
+        if client_credential?
+          Restforce::Middleware::Authentication::ClientCredential
+        elsif username_password?
           Restforce::Middleware::Authentication::Password
         elsif oauth_refresh?
           Restforce::Middleware::Authentication::Token
         elsif jwt?
           Restforce::Middleware::Authentication::JWTBearer
         end
+      end
+
+      def client_credential?
+        options[:client_id] && options[:client_secret]
       end
 
       # Internal: Returns true if username/password (autonomous) flow should be used for

--- a/lib/restforce/concerns/authentication.rb
+++ b/lib/restforce/concerns/authentication.rb
@@ -15,19 +15,15 @@ module Restforce
 
       # Internal: Determines what middleware will be used based on the options provided
       def authentication_middleware
-        if client_credential?
-          Restforce::Middleware::Authentication::ClientCredential
-        elsif username_password?
+        if username_password?
           Restforce::Middleware::Authentication::Password
         elsif oauth_refresh?
           Restforce::Middleware::Authentication::Token
         elsif jwt?
           Restforce::Middleware::Authentication::JWTBearer
+        elsif client_credential?
+          Restforce::Middleware::Authentication::ClientCredential
         end
-      end
-
-      def client_credential?
-        options[:client_id] && options[:client_secret]
       end
 
       # Internal: Returns true if username/password (autonomous) flow should be used for
@@ -53,6 +49,12 @@ module Restforce
         options[:jwt_key] &&
           options[:username] &&
           options[:client_id]
+      end
+
+      # Internal: Returns true if client credential flow should be used for
+      # authentication.
+      def client_credential?
+        options[:client_id] && options[:client_secret]
       end
     end
   end

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -9,6 +9,7 @@ module Restforce
     autoload :Password,  'restforce/middleware/authentication/password'
     autoload :Token,     'restforce/middleware/authentication/token'
     autoload :JWTBearer, 'restforce/middleware/authentication/jwt_bearer'
+    autoload :ClientCredential, 'restforce/middleware/authentication/client_credential'
 
     # Rescue from 401's, authenticate then raise the error again so the client
     # can reissue the request.

--- a/lib/restforce/middleware/authentication/client_credential.rb
+++ b/lib/restforce/middleware/authentication/client_credential.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Restforce
+  class Middleware
+    class Authentication
+      class ClientCredential < Restforce::Middleware::Authentication
+        def params
+          { grant_type: 'client_credentials',
+            client_id: @options[:client_id],
+            client_secret: @options[:client_secret] }
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/concerns/authentication_spec.rb
+++ b/spec/unit/concerns/authentication_spec.rb
@@ -36,17 +36,8 @@ describe Restforce::Concerns::Authentication do
   describe '.authentication_middleware' do
     subject { client.authentication_middleware }
 
-    context 'when client_id and client_secret options are provided' do
-      before do
-        client.stub client_credential?: true
-      end
-
-      it { should eq Restforce::Middleware::Authentication::ClientCredential }
-    end
-
     context 'when username and password options are provided' do
       before do
-        client.stub client_credential?: false
         client.stub username_password?: true
       end
 
@@ -55,7 +46,6 @@ describe Restforce::Concerns::Authentication do
 
     context 'when oauth options are provided' do
       before do
-        client.stub client_credential?: false
         client.stub username_password?: false
         client.stub oauth_refresh?: true
       end
@@ -65,13 +55,23 @@ describe Restforce::Concerns::Authentication do
 
     context 'when jwt option is provided' do
       before do
-        client.stub client_credential?: false
         client.stub username_password?: false
         client.stub oauth_refresh?: false
         client.stub jwt?: true
       end
 
       it { should eq Restforce::Middleware::Authentication::JWTBearer }
+    end
+
+    context 'when client_id and client_secret options are provided' do
+      before do
+        client.stub username_password?: false
+        client.stub oauth_refresh?: false
+        client.stub jwt?: false
+        client.stub client_credential?: true
+      end
+
+      it { should eq Restforce::Middleware::Authentication::ClientCredential }
     end
   end
 

--- a/spec/unit/concerns/authentication_spec.rb
+++ b/spec/unit/concerns/authentication_spec.rb
@@ -36,8 +36,17 @@ describe Restforce::Concerns::Authentication do
   describe '.authentication_middleware' do
     subject { client.authentication_middleware }
 
+    context 'when client_id and client_secret options are provided' do
+      before do
+        client.stub client_credential?: true
+      end
+
+      it { should eq Restforce::Middleware::Authentication::ClientCredential }
+    end
+
     context 'when username and password options are provided' do
       before do
+        client.stub client_credential?: false
         client.stub username_password?: true
       end
 
@@ -46,6 +55,7 @@ describe Restforce::Concerns::Authentication do
 
     context 'when oauth options are provided' do
       before do
+        client.stub client_credential?: false
         client.stub username_password?: false
         client.stub oauth_refresh?: true
       end
@@ -55,6 +65,7 @@ describe Restforce::Concerns::Authentication do
 
     context 'when jwt option is provided' do
       before do
+        client.stub client_credential?: false
         client.stub username_password?: false
         client.stub oauth_refresh?: false
         client.stub jwt?: true

--- a/spec/unit/concerns/authentication_spec.rb
+++ b/spec/unit/concerns/authentication_spec.rb
@@ -146,4 +146,26 @@ describe Restforce::Concerns::Authentication do
       it { should_not be true }
     end
   end
+
+  describe '.client_credential?' do
+    subject       { client.client_credential? }
+    let(:options) { {} }
+
+    before do
+      client.stub options: options
+    end
+
+    context 'when oauth client_credentials options are provided' do
+      let(:options) do
+        { client_id: 'client',
+          client_secret: 'secret' }
+      end
+
+      it { should be_truthy }
+    end
+
+    context 'when oauth client_credentials are not provided' do
+      it { should_not be true }
+    end
+  end
 end

--- a/spec/unit/concerns/authentication_spec.rb
+++ b/spec/unit/concerns/authentication_spec.rb
@@ -155,7 +155,7 @@ describe Restforce::Concerns::Authentication do
       client.stub options: options
     end
 
-    context 'when oauth client_credentials options are provided' do
+    context 'when oauth client credential options are provided' do
       let(:options) do
         { client_id: 'client',
           client_secret: 'secret' }
@@ -164,7 +164,7 @@ describe Restforce::Concerns::Authentication do
       it { should be_truthy }
     end
 
-    context 'when oauth client_credentials are not provided' do
+    context 'when oauth client credential options are not provided' do
       it { should_not be true }
     end
   end

--- a/spec/unit/middleware/authentication/client_credential_spec.rb
+++ b/spec/unit/middleware/authentication/client_credential_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Restforce::Middleware::Authentication::ClientCredential do
+  let(:options) do
+    { host: 'login.salesforce.com',
+      client_id: 'client_id',
+      client_secret: 'client_secret',
+      adapter: :net_http }
+  end
+
+  it_behaves_like 'authentication middleware' do
+    let(:success_request) do
+      stub_login_request(
+        body: "grant_type=client_credentials&" \
+              "client_id=client_id&client_secret=client_secret"
+      ).to_return(
+        status: 200,
+        body: fixture(:auth_success_response),
+        headers: { "Content-Type" => "application/json" }
+      )
+    end
+
+    let(:fail_request) do
+      stub_login_request(
+        body: "grant_type=client_credentials&" \
+              "client_id=client_id&client_secret=client_secret"
+      ).to_return(
+        status: 400,
+        body: fixture(:refresh_error_response),
+        headers: { "Content-Type" => "application/json" }
+      )
+    end
+  end
+end


### PR DESCRIPTION
add support `grant_type=client_credentials`

OAuth 2.0 Client Credentials
https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5