### PR TITLE
Remove outdated link from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,13 +831,6 @@ client.create!("CustomField", {
 })
 ```
 
-## Links
-
-If you need a full Active Record experience, may be you can use
-[ActiveForce](https://github.com/ionia-corporation/active_force) that wraps
-Restforce and adds Associations, Query Building (like AREL), Validations and
-Callbacks.
-
 ## Contributing
 
 We welcome all contributions - they help us make Restforce the best gem possible.


### PR DESCRIPTION
Looks like `active_force` is archived.