### PR TITLE
Register JSON middleware as restforce_json to avoid overwriting default

### DIFF
--- a/lib/restforce/concerns/connection.rb
+++ b/lib/restforce/concerns/connection.rb
@@ -33,7 +33,7 @@ module Restforce
           # Handles multipart file uploads for blobs.
           builder.use Restforce::Middleware::Multipart
           # Converts the request into JSON.
-          builder.request :json
+          builder.request :restforce_json
           # Handles reauthentication for 403 responses.
           if authentication_middleware
             builder.use authentication_middleware, self, options
@@ -52,7 +52,7 @@ module Restforce
           # Raises errors for 40x responses.
           builder.use Restforce::Middleware::RaiseError
           # Parses returned JSON response into a hash.
-          builder.response :json, content_type: /\bjson$/
+          builder.response :restforce_json, content_type: /\bjson$/
           # Compress/Decompress the request/response
           unless adapter == :httpclient
             builder.use Restforce::Middleware::Gzip, self, options

--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -50,7 +50,7 @@ module Restforce
         builder.use Faraday::Request::UrlEncoded
         builder.use Restforce::Middleware::Mashify, nil, @options
         builder.use Faraday::FollowRedirects::Middleware
-        builder.response :json
+        builder.response :restforce_json
 
         if Restforce.log?
           builder.use Restforce::Middleware::Logger,

--- a/lib/restforce/middleware/json_request.rb
+++ b/lib/restforce/middleware/json_request.rb
@@ -87,4 +87,4 @@ module Restforce
   end
 end
 
-Faraday::Request.register_middleware(json: Restforce::Middleware::JsonRequest)
+Faraday::Request.register_middleware(restforce_json: Restforce::Middleware::JsonRequest)

--- a/lib/restforce/middleware/json_response.rb
+++ b/lib/restforce/middleware/json_response.rb
@@ -82,4 +82,4 @@ module Restforce
   end
 end
 
-Faraday::Response.register_middleware(json: Restforce::Middleware::JsonResponse)
+Faraday::Response.register_middleware(restforce_json: Restforce::Middleware::JsonResponse)


### PR DESCRIPTION
Since the gem was registering it's own custom JSON middleware as `:json` it could end up taking precedence over the default Faraday JSON middleware in application code and break things.

This PR changes the registration name to `:restforce_json` to avoid any chance of collision.