### PR TITLE
Drop support for Ruby 2.7, which has reached end-of-life

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.7', '3.0', '3.1', '3.2']
+        ruby_version: ['3.0', '3.1', '3.2']
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - .*/**/*
     - vendor/**/*
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Limit lines to 90 characters.
 Layout/LineLength:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Or install it yourself as:
 
     $ gem install restforce
 
-__As of version 6.0.0, this gem is only compatible with Ruby 2.7.0 and later.__ If you're using an earlier Ruby version:
+__As of version 7.0.0, this gem is only compatible with Ruby 3.0.0 and later.__ If you're using an earlier Ruby version:
 
+* for Ruby 2.7, use version 6.2.4 or earlier
 * for Ruby 2.6, use version 5.3.1 or earlier
 * for Ruby 2.5, use version 5.0.6 or earlier
 * for Ruby 2.4, use version 4.3.0 or earlier

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,15 @@
+# Upgrading from Restforce 6.x to 7.x
+
+## Ruby 2.7 is no longer supported
+
+__Likelyhood of impact__: Moderate
+
+Ruby 2.7 is no longer officially supported as an active version of the Ruby language. That means that it will not receive patches and security fixes.
+
+Accordingly, we've dropped support for Ruby 2.7 in the Restforce library. The gemspec now specifies that only 3.0 onwards is supported, and this will be enforced by RubyGems.
+
+Before you update to Restforce 7.x, you'll need to switch to Ruby 3.0.0 or later. The current version of Ruby at the time of writing is 3.2.2.
+
 # Upgrading from Restforce 5.x to 6.x
 
 __There are two breaking changes introduced in Restforce 6.x__. In this guide, you'll learn about these changes and what you should check in your code to make sure that it will work with the latest version of the library.

--- a/lib/restforce/middleware/json_request.rb
+++ b/lib/restforce/middleware/json_request.rb
@@ -31,7 +31,7 @@ module Restforce
     CONTENT_TYPE = 'Content-Type'
 
     MIME_TYPE = 'application/json'
-    MIME_TYPE_REGEX = %r{^application/(vnd\..+\+)?json$}.freeze
+    MIME_TYPE_REGEX = %r{^application/(vnd\..+\+)?json$}
 
     #
     # Taken from `lib/faraday/middleware.rb` in the `faraday`

--- a/lib/restforce/middleware/raise_error.rb
+++ b/lib/restforce/middleware/raise_error.rb
@@ -60,7 +60,7 @@ module Restforce
       }
     end
 
-    ERROR_CODE_MATCHER = /\A[A-Z_]+\z/.freeze
+    ERROR_CODE_MATCHER = /\A[A-Z_]+\z/
 
     def exception_class_for_error_code(error_code)
       return Restforce::ResponseError unless ERROR_CODE_MATCHER.match?(error_code)

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 'rubygems_mfa_required' => 'true'
   }
 
-  gem.required_ruby_version = '>= 2.7'
+  gem.required_ruby_version = '>= 3.0'
 
   gem.add_dependency 'faraday', '< 2.8.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '<= 0.3.0', '< 1.0.0'


### PR DESCRIPTION
In keeping with Restforce's usual practice, this ends supports for Ruby 2.7, which has reached end of life and is no longer supported or kept up to date with security patches.

This change will be released as a new major version, v7.0.0.