### PR TITLE
v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 6.2.4 (Oct 8, 2023)
+# 7.0.0 (Oct 6, 2023)
+
+__This version contains breaking changes. For help with upgrading, see [`UPGRADING.md`](https://github.com/restforce/restforce/blob/main/UPGRADING.md).__
+
+* __⚠️  Drop support for Ruby 2.7__, since [Ruby 2.7 has reached its end-of-life](https://www.ruby-lang.org/en/downloads/) (@timrogers)
+
+# 6.2.4 (Oct 6, 2023)
 
 * Register the custom JSON middleware for Faraday with a more unique name to avoid clashes with other middleware (@dbackeus)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features include:
 
 Add this line to your application's Gemfile:
 
-    gem 'restforce', '~> 6.2.4'
+    gem 'restforce', '~> 7.0.0'
 
 And then execute:
 

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Restforce
-  VERSION = '6.2.4'
+  VERSION = '7.0.0'
 end


### PR DESCRIPTION
__This version contains breaking changes. For help with upgrading, see
[`UPGRADING.md`](https://github.com/restforce/restforce/blob/main/UPGRADING.md).__

* __⚠️  Drop support for Ruby 2.7__, since [Ruby 2.7 has reached its end-of-life](https://www.ruby-lang.org/en/downloads/) (@timrogers)

*This PR also fixes the changelog date on v6.2.4, which was incorrect.*