### PR TITLE
v7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 7.1.0 (Dec 20, 2023)
+
+- Add support for the [OAuth 2.0 Client Credentials authentication flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5) (@rh-taro)
+- Add support for `faraday` v2.8.x (@timrogers)
+
 # 7.0.0 (Oct 6, 2023)
 
 __This version contains breaking changes. For help with upgrading, see [`UPGRADING.md`](https://github.com/restforce/restforce/blob/main/UPGRADING.md).__

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ so you can do things like `client.query('select Id, (select Name from Children__
 
 Which authentication method you use really depends on your use case. If you're
 building an application where many users from different organizations are authenticated
-through oauth and you need to interact with data in their org on their behalf,
+through OAuth and you need to interact with data in their org on their behalf,
 you should use the OAuth token authentication method.
 
 If you're using the gem to interact with a single org (maybe you're building some
@@ -154,6 +154,17 @@ client = Restforce.new
 ```
 
 **Note:** Restforce library does not cache JWT Bearer tokens automatically. This means that every instantiation of the Restforce class will be treated as a new login by Salesforce. Remember that Salesforce enforces [rate limits on login requests](https://help.salesforce.com/s/articleView?id=000312767&type=1). If you are building an application that will instantiate the Restforce class more than this specified rate limit, you might want to consider caching the Bearer token either in-memory or in your own storage by leveraging the `authentication_callback` method. 
+
+## Client Credentials
+
+If you want to authenticate as an application, you can use the [Client Credentials flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5):
+
+```ruby
+client = Restforce.new(client_id: 'client_id',
+                       client_secret: 'client_secret',
+                       api_version: '55.0',
+                       instance_url: 'instance_url')
+```
 
 #### Sandbox Organizations
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features include:
 
 Add this line to your application's Gemfile:
 
-    gem 'restforce', '~> 7.0.0'
+    gem 'restforce', '~> 7.1.0'
 
 And then execute:
 

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Restforce
-  VERSION = '7.0.0'
+  VERSION = '7.1.0'
 end


### PR DESCRIPTION
- Add support for the [OAuth 2.0 Client Credentials authentication flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5)
(@rh-taro)
- Add support for `faraday` v2.8.x (@timrogers)

This PR also updates the readme to document the Client Credentials authentication flow implemented in #814.