### PR TITLE
Add support for `faraday` v2.8.x

### DIFF
--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -10,7 +10,7 @@ jobs:
         # For v2.0.x, we test v2.0.0 and v2.0.1 because v2.0.0 has a special behaviour where
         # the Net::HTTP adapter is not included. See
         # https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20.
-        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.3', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.3', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.2', '2.6.0', '2.7.11']
+        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.3', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.3', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.2', '2.6.0', '2.7.12', '2.8.0']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 gemspec
 
-faraday_version = ENV.fetch('FARADAY_VERSION', '~> 2.7.3')
+faraday_version = ENV.fetch('FARADAY_VERSION', '~> 2.8.0')
 
 # Enable us to explicitly pick a Faraday version when running tests
 gem 'faraday', faraday_version

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.0'
 
-  gem.add_dependency 'faraday', '< 2.8.0', '>= 1.1.0'
+  gem.add_dependency 'faraday', '< 2.9.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '<= 0.3.0', '< 1.0.0'
   gem.add_dependency 'faraday-multipart', '>= 1.0.0', '< 2.0.0'
   gem.add_dependency 'faraday-net_http', '< 4.0.0'


### PR DESCRIPTION
This adds support for `faraday` v2.8.x, and tests the gem against that Faraday version as part of our CI process. We will also now use v2.8.x by default in development and testing.