### PR TITLE
Composite API: Add support for GET

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,6 @@ This feature permits the user to send a composite object—that is, a complex
 object with nested children—in a single API call. Up to 25 requests may be
 included in a single composite.
 
-Note that `GET` is not yet implemented for this API.
 
 ```ruby
 # build up an array of requests:

--- a/lib/restforce/concerns/composite_api.rb
+++ b/lib/restforce/concerns/composite_api.rb
@@ -93,6 +93,14 @@ module Restforce
           }
         end
 
+        def find(sobject, reference_id, id)
+          requests << {
+            method: 'GET',
+            url: composite_api_path("#{sobject}/#{id}"),
+            referenceId: reference_id
+          }
+        end
+
         private
 
         def composite_api_path(path)

--- a/spec/unit/concerns/composite_api_spec.rb
+++ b/spec/unit/concerns/composite_api_spec.rb
@@ -82,6 +82,23 @@ describe Restforce::Concerns::CompositeAPI do
       end
     end
 
+    it '#find' do
+      client.
+        should_receive(:api_post).
+        with(endpoint, { compositeRequest: [
+          {
+            method: 'GET',
+            url: "/services/data/v38.0/sobjects/Object/00312345",
+            referenceId: 'find_ref'
+          }
+        ], allOrNone: all_or_none, collateSubrequests: false }.to_json).
+        and_return(response)
+
+      client.send(method) do |subrequests|
+        subrequests.find('Object', 'find_ref', '00312345')
+      end
+    end
+
     it 'multiple subrequests' do
       client.
         should_receive(:api_post).


### PR DESCRIPTION
### Summary
Add support for GET request in Composite API library. 
https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm#subrequest
