### PR TITLE
Updates README to reflect the need to set `host` option, not `instance_url` when doing Client Credentials flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ client = Restforce.new
 
 **Note:** Restforce library does not cache JWT Bearer tokens automatically. This means that every instantiation of the Restforce class will be treated as a new login by Salesforce. Remember that Salesforce enforces [rate limits on login requests](https://help.salesforce.com/s/articleView?id=000312767&type=1). If you are building an application that will instantiate the Restforce class more than this specified rate limit, you might want to consider caching the Bearer token either in-memory or in your own storage by leveraging the `authentication_callback` method. 
 
-## Client Credentials
+#### Client Credentials
 
 If you want to authenticate as an application, you can use the [Client Credentials flow](https://help.salesforce.com/s/articleView?id=sf.remoteaccess_oauth_client_credentials_flow.htm&type=5):
 
@@ -163,7 +163,7 @@ If you want to authenticate as an application, you can use the [Client Credentia
 client = Restforce.new(client_id: 'client_id',
                        client_secret: 'client_secret',
                        api_version: '55.0',
-                       instance_url: 'instance_url')
+                       host: 'MYDOMAIN.my.salesforce.com')
 ```
 
 #### Sandbox Organizations


### PR DESCRIPTION
@rh-taro  -- the README misled me into setting instance_url but that's now how Client Cred flow needs to work -- the authorization request needs to be made against the org's My Domain which means you need to set the `host` option, not `instance_url`

Can you review this README change and then @timrogers can you merge it? 

Thanks!