### PR TITLE
Add back ActiveForce to the README as the project has new owners.

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,6 +842,13 @@ client.create!("CustomField", {
 })
 ```
 
+## Links
+
+If you need a full Active Record experience, may be you can use
+[ActiveForce](https://github.com/Beyond-Finance/active_force) that wraps
+Restforce and adds Associations, Query Building (like AREL), Validations and
+Callbacks.
+
 ## Contributing
 
 We welcome all contributions - they help us make Restforce the best gem possible.


### PR DESCRIPTION
Hey folks! My company has taken over the ActiveForce repo and has been given ownership of the gem on Rubygems.org.  Would you mind merging this info back into the README?