### PR TITLE
Explicitly require `StringIO` where it's used

### DIFF
--- a/lib/restforce/middleware/gzip.rb
+++ b/lib/restforce/middleware/gzip.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'stringio'
 require 'zlib'
 
 module Restforce

--- a/lib/restforce/patches/parts.rb
+++ b/lib/restforce/patches/parts.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 module Faraday
   module Parts
     module Part

--- a/spec/unit/middleware/gzip_spec.rb
+++ b/spec/unit/middleware/gzip_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'stringio'
+
 require 'spec_helper'
 
 describe Restforce::Middleware::Gzip do


### PR DESCRIPTION
Fixes #871.