### PR TITLE
Handle JWT Auth Issue were `aud` is diff then `host`

### DIFF
--- a/lib/restforce/middleware/authentication/jwt_bearer.rb
+++ b/lib/restforce/middleware/authentication/jwt_bearer.rb
@@ -23,7 +23,7 @@ module Restforce
           {
             iss: @options[:client_id],
             sub: @options[:username],
-            aud: @options[:host],
+            aud: @options[:aud] || @options[:host],
             iat: Time.now.utc.to_i,
             exp: Time.now.utc.to_i + 180
           }


### PR DESCRIPTION
# Issue Description
When we are using JWT authentication, for a few of our customers we were unable to generate the token with `https://login.salesforce.com/services/oauth2/token`.
It has to be with their custom domain such as `https://mydomain.my.salesforce.com/services/oauth2/token`
But at same time we should use `aud` as `login.salesforce.com` else we were getting `invalid_grant: user hasn't approved this consumer` excepting

And today in the gem we were not having any option to pass `aud` separately
So we have just introduced handling for the `aud` in options for JWT

# Code Examples
### Old way to create rest client
```
client = Restforce.new(
        api_version: api_version,
        username: username,
        client_id: client_id,
        jwt_key: jwt_key,
        host: host
)
```

### New way to create rest client
```
client = Restforce.new(
        api_version: api_version,
        username: username,
        client_id: client_id,
        jwt_key: jwt_key,
        # aud is an optional attribute, if you are not using custom domain, no need to pass it
        aud: 'https://login.salesforce.com/', # for sandboxes please use 'https://test.salesforce.com'
        host: host
)
```
