### PR TITLE
Test with `faraday` v1.10.0, v1.10.1 and v1.10.2 to check compatibility

### DIFF
--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -10,7 +10,7 @@ jobs:
         # For v2.0.x, we test v2.0.0 and v2.0.1 because v2.0.0 has a special behaviour where
         # the Net::HTTP adapter is not included. See
         # https://github.com/lostisland/faraday/blob/main/UPGRADING.md#faraday-20.
-        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.3', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.3', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.2', '2.6.0', '2.7.12', '2.8.1', '2.9.1']
+        faraday_version: ['1.1.0', '1.2.0', '1.3.1', '1.4.3', '1.5.1', '1.6.0', '1.7.2', '1.8.0', '1.9.3', '1.10.0', '1.10.1', '1.10.2', '1.10.3', '2.0.0', '2.0.1', '2.1.0', '2.2.0', '2.3.0', '2.4.0', '2.5.2', '2.6.0', '2.7.12', '2.8.1', '2.9.1']
     env:
       FARADAY_VERSION: ~> ${{ matrix.faraday_version }}
     steps:


### PR DESCRIPTION
See #889 for context.