### PR TITLE
Fix host parameter documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ If you prefer to use a username and password to authenticate:
 client = Restforce.new(username: config['username'],
                        password: config['password'],
                        instance_url: config['instance_url'],
-                       host: config['host'],                   # https://test.salesforce.com for sandbox (optional)
+                       host: config['host'],                   # test.salesforce.com for sandbox (optional)
                        client_id: config['client_key'],        # Salesforce Client Key
                        client_secret: config['client_secret'], # Salesforce Client Secret
                        api_version: '55.0')


### PR DESCRIPTION
This PR fixes an issue in the documentation where the host parameter for Restforce was incorrectly shown with the https:// protocol. The correct usage is to provide only the domain name, such as login.salesforce.com or test.salesforce.com. This update ensures that future users will avoid connection issues related to improperly formatted URLs.

Error when using incorrect URL 

```
#<Faraday::ConnectionFailed wrapped=#<SocketError: Failed to open TCP connection to https:443 (getaddrinfo: Name or service not known)>>
```