### PR TITLE
Allow `faraday` versions up to, but not including, v3.0.0

### DIFF
--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 3.0'
 
-  gem.add_dependency 'faraday', '< 2.12.0', '>= 1.1.0'
+  gem.add_dependency 'faraday', '< 3.0.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '<= 0.3.0', '< 1.0.0'
   gem.add_dependency 'faraday-multipart', '>= 1.0.0', '< 2.0.0'
   gem.add_dependency 'faraday-net_http', '< 4.0.0'


### PR DESCRIPTION
Following user feedback in #901, this updates the gem's dependencies to allow `faraday` versions up to (but not including) v3.0.0.

Previously, due to breaking changes released in minor Faraday versions (see #701 for an example), we have individually vetted new minor versions before declaring Restforce to be compatible.

However, this can slow down apps' Faraday upgrades, and leads to an [odd behaviour][1] where a very old version is installed by default.

We will now automatically allow new minor versions, and a check will only be required for new Faraday major versions. This entails some risk of new minor Faraday versions breaking things - but that's a risk we can choose to take.

[1]: https://github.com/rubygems/rubygems/issues/8002#issuecomment-2328725079