### PR TITLE
v7.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.6.0 (December 18, 2024)
+
+- **Allow all `faraday` versions up to, but not including, v3.0.0**: For more details, see https://github.com/restforce/restforce/pull/915 (@timrogers)
+
 ## 7.5.0 (September 4, 2024)
 
 - Add support for `faraday` v2.11.x (@timrogers)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/restforce/restforce.svg?style=svg)](https://circleci.com/gh/restforce/restforce)
 ![Downloads](https://img.shields.io/gem/dt/restforce.svg)
 
-Restforce is a ruby gem for the [Salesforce REST api](http://www.salesforce.com/us/developer/docs/api_rest/index.htm).
+Restforce is a ruby gem for the [Salesforce REST API](http://www.salesforce.com/us/developer/docs/api_rest/index.htm).
 
 Features include:
 

--- a/lib/restforce/version.rb
+++ b/lib/restforce/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Restforce
-  VERSION = '7.5.0'
+  VERSION = '7.6.0'
 end


### PR DESCRIPTION
- **Allow all `faraday` versions up to, but not including, v3.0.0**: For more details, see https://github.com/restforce/restforce/pull/915 (@timrogers)