### PR TITLE
Use request timeout during Salesforce authentication

### DIFF
--- a/lib/restforce/middleware/authentication.rb
+++ b/lib/restforce/middleware/authentication.rb
@@ -88,9 +88,15 @@ module Restforce
     private
 
     def faraday_options
-      { url: "https://#{@options[:host]}",
+      {
+        url: "https://#{@options[:host]}",
         proxy: @options[:proxy_uri],
-        ssl: @options[:ssl] }
+        ssl: @options[:ssl],
+        request: {
+          timeout: @options[:timeout],
+          open_timeout: @options[:timeout]
+        }
+      }
     end
   end
 end

--- a/spec/unit/middleware/authentication_spec.rb
+++ b/spec/unit/middleware/authentication_spec.rb
@@ -9,8 +9,9 @@ describe Restforce::Middleware::Authentication do
       authentication_retries: retries,
       adapter: :net_http,
       # rubocop:disable Naming/VariableNumber
-      ssl: { version: :TLSv1_2 } }
-    # rubocop:enable Naming/VariableNumber
+      ssl: { version: :TLSv1_2 },
+      # rubocop:enable Naming/VariableNumber
+      timeout: 10 }
   end
 
   describe '.authenticate!' do


### PR DESCRIPTION
# Allow http request read/open timeout to be set for Authentication.

On https://github.com/restforce/restforce/pull/51 the timeout option was introduced in Restforce. However, it was not set in the Authentication middleware.

The timeout set for the authentication will be the same as for the other requests.