### PR TITLE
Fix setting global use_cache to false

### DIFF
--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -73,11 +73,15 @@ module Restforce
         our_default = default
         our_name    = name
         configuration.send :define_method, our_name do
-          instance_variable_get(:"@#{our_name}") ||
+          value = instance_variable_get(:"@#{our_name}")
+          if value.nil?
             instance_variable_set(
               :"@#{our_name}",
               our_default.respond_to?(:call) ? our_default.call : our_default
             )
+          else
+            value
+          end
         end
       end
     end

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -71,6 +71,13 @@ describe Restforce do
       end
     end
 
+    it "allows use_cache to be set" do
+      Restforce.configure do |config|
+        config.use_cache = false
+      end
+      expect(Restforce.configuration.use_cache).to be false
+    end
+
     it 'takes precedence over environment variables' do
       { 'SALESFORCE_USERNAME'  => 'env_foo',
         'SALESFORCE_CLIENT_ID' => 'env_client id' }.


### PR DESCRIPTION
The README [suggests](https://github.com/restforce/restforce#:~:text=you%20prefer%20to-,opt%20in%20to%20caching,-on%20a%20per) this pattern to opt-in to caching:

```rb
Restforce.configure do |config|
  config.cache = Rails.cache
  config.use_cache = false
end

client.with_caching { ... }
```

Unfortunately, this doesn't actually work due to the way `Configuration` uses `||` to define the accessor methods:

```rb
Restforce.configure do |config|
  config.use_cache = false
end

client = Restforce.new
client.options[:use_cache]
=> true
```

This PR changes the accessor methods to explicitly check for `nil` instead, to ensure `false` doesn't get clobbered.
