### PR TITLE
Drop support for Ruby 3.1.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby_version: ["3.2", "3.3", "3.4", "4.0"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.1
+          ruby-version: 4.0
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.2
+          ruby-version: 4.0
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.3
+          ruby-version: 3.2
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 4.0
+          ruby-version: 3.4
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.github/workflows/faraday.yml
+++ b/.github/workflows/faraday.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.4
+          ruby-version: 3.3
       - name: Install dependencies
         run: bundle install
       - name: Run RSpec tests

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - .*/**/*
     - vendor/**/*
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Limit lines to 90 characters.
 Layout/LineLength:

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -84,8 +84,8 @@ module Restforce
     end
 
     # Helper for decoding signed requests.
-    def decode_signed_request(*args)
-      SignedRequest.decode(*args)
+    def decode_signed_request(*)
+      SignedRequest.decode(*)
     end
   end
 

--- a/lib/restforce.rb
+++ b/lib/restforce.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday/net_http'
 require 'faraday/follow_redirects'
 require 'json'
 require 'jwt'

--- a/lib/restforce/concerns/api.rb
+++ b/lib/restforce/concerns/api.rb
@@ -263,8 +263,8 @@ module Restforce
       #
       # Returns the String Id of the newly created sobject.
       # Returns false if something bad happens.
-      def create(*args)
-        create!(*args)
+      def create(*)
+        create!(*)
       rescue *exceptions
         false
       end
@@ -300,8 +300,8 @@ module Restforce
       #
       # Returns true if the sobject was successfully updated.
       # Returns false if there was an error.
-      def update(*args)
-        update!(*args)
+      def update(*)
+        update!(*)
       rescue *exceptions
         false
       end
@@ -342,8 +342,8 @@ module Restforce
       # Returns the Id of the newly created record if the record was created.
       # Returns false if something bad happens (for example if the external ID matches
       # multiple resources).
-      def upsert(*args)
-        upsert!(*args)
+      def upsert(*)
+        upsert!(*)
       rescue *exceptions
         false
       end
@@ -398,8 +398,8 @@ module Restforce
       #
       # Returns true if the sobject was successfully deleted.
       # Returns false if an error is returned from Salesforce.
-      def destroy(*args)
-        destroy!(*args)
+      def destroy(*)
+        destroy!(*)
       rescue *exceptions
         false
       end

--- a/lib/restforce/concerns/composite_api.rb
+++ b/lib/restforce/concerns/composite_api.rb
@@ -35,8 +35,8 @@ module Restforce
         results
       end
 
-      def composite!(collate_subrequests: false, &block)
-        composite(all_or_none: true, collate_subrequests: collate_subrequests, &block)
+      def composite!(collate_subrequests: false, &)
+        composite(all_or_none: true, collate_subrequests: collate_subrequests, &)
       end
 
       class Subrequests

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -43,8 +43,8 @@ module Restforce
     class Option
       attr_reader :configuration, :name, :options
 
-      def self.define(*args)
-        new(*args).define
+      def self.define(*)
+        new(*).define
       end
 
       def initialize(configuration, name, options = {})
@@ -85,8 +85,8 @@ module Restforce
     class << self
       attr_accessor :options
 
-      def option(*args)
-        option = Option.define(self, *args)
+      def option(*)
+        option = Option.define(self, *)
         (self.options ||= []) << option.name
       end
     end

--- a/lib/restforce/config.rb
+++ b/lib/restforce/config.rb
@@ -139,7 +139,8 @@ module Restforce
     option :timeout
 
     # Faraday adapter to use. Defaults to Faraday.default_adapter.
-    option :adapter, default: lambda { Faraday.default_adapter }
+    # In Faraday 2.0.0, default_adapter returns nil, so we fall back to :net_http.
+    option :adapter, default: lambda { Faraday.default_adapter || :net_http }
 
     option :proxy_uri, default: lambda { ENV.fetch('SALESFORCE_PROXY_URI', nil) }
 

--- a/lib/restforce/middleware/json_response.rb
+++ b/lib/restforce/middleware/json_response.rb
@@ -19,12 +19,20 @@ module Restforce
     # Faraday. In Faraday, this refers to a Faraday constant.
     CONTENT_TYPE = 'Content-Type'
 
-    def initialize(app = nil, parser_options: nil, content_type: /\bjson$/,
-                   preserve_raw: false)
+    # In older Faraday 1.x versions, the DependencyLoader module's `new` method
+    # uses `def new(*)` which doesn't forward keyword arguments properly in Ruby 3+.
+    # This causes keyword arguments like `content_type:` to be converted to a Hash
+    # and passed as a second positional argument. We handle both cases here.
+    def initialize(app = nil, options = nil, **kwargs)
       super(app)
-      @parser_options = parser_options
-      @content_types = Array(content_type)
-      @preserve_raw = preserve_raw
+
+      # If options is a Hash, it means we received keyword args as a positional hash
+      # (Faraday 1.x with Ruby 3+). Otherwise, use kwargs (Faraday 2.x style).
+      opts = options.is_a?(Hash) ? options : kwargs
+
+      @parser_options = opts[:parser_options]
+      @content_types = Array(opts[:content_type] || /\bjson$/)
+      @preserve_raw = opts[:preserve_raw] || false
     end
 
     #

--- a/restforce.gemspec
+++ b/restforce.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
 'rubygems_mfa_required' => 'true'
   }
 
-  gem.required_ruby_version = '>= 3.1'
+  gem.required_ruby_version = '>= 3.2'
 
   gem.add_dependency 'faraday', '< 3.0.0', '>= 1.1.0'
   gem.add_dependency 'faraday-follow_redirects', '< 0.6.0'

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -25,7 +25,7 @@ describe Restforce do
       its(:api_version)            { should eq '26.0' }
       its(:host)                   { should eq 'login.salesforce.com' }
       its(:authentication_retries) { should eq 3 }
-      its(:adapter)                { should eq Faraday.default_adapter }
+      its(:adapter)                { should eq(Faraday.default_adapter || :net_http) }
       its(:ssl)                    { should eq({}) }
       %i[username password security_token client_id client_secret
          oauth_token refresh_token instance_url compress timeout


### PR DESCRIPTION
This drops support for Ruby 3.1.x by blocking it in the gemspec.

Alongside that change, I also stop testing against Ruby 3.1.x in CI (including shifting the default Ruby version to the latest, v4.0.x), update the Rubocop config to target 3.2 and apply outstanding Rubocop fixes.